### PR TITLE
Introducing `Microstate.from` to immutably transition arbitrary POJOs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import './typeclasses';
 import Microstate from './microstate';
 
 export default Microstate;
-export const { create } = Microstate;
+export const { create, from } = Microstate;
 
 export { default as Microstate } from './microstate';
 export { default as Tree } from './utils/tree';

--- a/src/microstate.js
+++ b/src/microstate.js
@@ -1,5 +1,5 @@
 import { map } from "funcadelic";
-import analyze, { collapseState } from "./structure";
+import analyze, { collapseState, analyzeFrom } from "./structure";
 import { keep, reveal } from "./utils/secret";
 import SymbolObservable from "symbol-observable";
 
@@ -20,6 +20,15 @@ export default class Microstate {
   static create(Type, value) {
     value = value != null ? value.valueOf() : value;
     let tree = analyze(Type, value);
+    return new Microstate(tree, value);
+  }
+
+  static from(value) {
+    // TODO: these should convert to Any
+    if (value === null || value === undefined) {
+      throw new Error(`Can not convert ${value} to a microstate with from.`)
+    }
+    let tree = analyzeFrom(value);
     return new Microstate(tree, value);
   }
 

--- a/src/structure.js
+++ b/src/structure.js
@@ -14,23 +14,25 @@ import { collapse } from './typeclasses/collapse';
 const { assign } = Object;
 
 export function analyzeFrom(value) {
-   if (typeof value === 'object') {
-    return flatMap(analyzeValue(value), pure(Tree, new Node(class {}, [])));
-  } else {
-    return pure(Tree, new Node(value.constructor, []));
-  }
+  return flatMap(analyzeValue(value), pure(Tree, new Node(value.constructor, [])));
 }
 
 function analyzeValue(value) {
   return node => {
-    let valueAt = node.valueAt(value);
-
-    return new Tree({
-      data: () => node,
-      children() {
-        return map((childValue, path) => graft(append(node.path, path), analyzeFrom(childValue)), valueAt);
-      }
-    })
+    if (node.Type === Object || node.Type === Array) {
+      let valueAt = node.valueAt(value);
+  
+      return new Tree({
+        data: () => node,
+        children() {
+          return map((childValue, path) => graft(append(node.path, path), analyzeFrom(childValue)), valueAt);
+        }
+      })
+    } else {
+      return new Tree({
+        data: () => node
+      })
+    }
   }
 }
 

--- a/src/structure.js
+++ b/src/structure.js
@@ -13,6 +13,27 @@ import { collapse } from './typeclasses/collapse';
 
 const { assign } = Object;
 
+export function analyzeFrom(value) {
+   if (typeof value === 'object') {
+    return flatMap(analyzeValue(value), pure(Tree, new Node(class {}, [])));
+  } else {
+    return pure(Tree, new Node(value.constructor, []));
+  }
+}
+
+function analyzeValue(value) {
+  return node => {
+    let valueAt = node.valueAt(value);
+
+    return new Tree({
+      data: () => node,
+      children() {
+        return map((childValue, path) => graft(append(node.path, path), analyzeFrom(childValue)), valueAt);
+      }
+    })
+  }
+}
+
 export default function analyze(Type, value) {
   return flatMap(analyzeType(value), pure(Tree, new Node(Type, [])));
 }

--- a/src/structure.js
+++ b/src/structure.js
@@ -14,11 +14,7 @@ import { collapse } from './typeclasses/collapse';
 const { assign } = Object;
 
 export function analyzeFrom(value) {
-  return flatMap(analyzeValue(value), pure(Tree, new Node(value.constructor, [])));
-}
-
-function analyzeValue(value) {
-  return node => {
+  return flatMap(node => {
     if (node.Type === Object || node.Type === Array) {
       let valueAt = node.valueAt(value);
   
@@ -33,7 +29,7 @@ function analyzeValue(value) {
         data: () => node
       })
     }
-  }
+  }, pure(Tree, new Node(value.constructor, [])));
 }
 
 export default function analyze(Type, value) {

--- a/tests/microstate.test.js
+++ b/tests/microstate.test.js
@@ -1,12 +1,12 @@
-import 'jest';
-import { create } from 'microstates';
-import { reveal } from '../src/utils/secret';
+import "jest";
+import { create, from } from "microstates";
+import { reveal } from "../src/utils/secret";
 
-it('exports create', function() {
+it("exports create", function() {
   expect(create).toBeInstanceOf(Function);
 });
 
-describe('create', () => {
+describe("create", () => {
   it(`uses valueOf microstates instance that's passed to it`, () => {
     class Person {
       name = String;
@@ -17,15 +17,95 @@ describe('create', () => {
   });
 });
 
-describe('valueOf', () => {
+describe("valueOf", () => {
   let ms;
   beforeEach(() => {
     ms = create(Number, 10);
   });
-  it('returns passed in value of', () => {
+  it("returns passed in value of", () => {
     expect(ms.valueOf()).toBe(10);
   });
-  it('is not enumerable', () => {
-    expect(Object.keys(ms).indexOf('valueOf')).toBe(-1);
+  it("is not enumerable", () => {
+    expect(Object.keys(ms).indexOf("valueOf")).toBe(-1);
   });
+});
+
+describe("from", () => {
+  it("is defined", () => {
+    expect(from).toBeInstanceOf(Function);
+  });
+
+  it("makes a number to microstate", () => {
+    let ms = from(42);
+    expect(ms).toMatchObject({
+      increment: expect.any(Function)
+    });
+    expect(ms.state).toBe(42);
+    expect(ms.valueOf()).toBe(42);
+  });
+
+  it("makes a boolean into a microstate", () => {
+    let ms = from(true);
+    expect(ms).toMatchObject({
+      toggle: expect.any(Function)
+    });
+    expect(ms.state).toBe(true);
+    expect(ms.valueOf()).toBe(true);
+  });
+
+  it("makes a string into a microstate", () => {
+    let ms = from("hello world");
+    expect(ms).toMatchObject({
+      concat: expect.any(Function)
+    });
+    expect(ms.state).toBe("hello world");
+    expect(ms.valueOf()).toBe("hello world");
+  });
+
+  it("throws an error for undefined or null", () => {
+    expect(() => {
+      from(null);
+    }).toThrowError(/Can not convert null to a microstate with from./);
+    expect(() => {
+      from(undefined);
+    }).toThrowError(/Can not convert undefined to a microstate with from./);
+  });
+
+  it("converts a primitive value on a ", () => {
+    let value = { string: "hello world", number: 42, boolean: false };
+    let ms = from(value);
+    expect(ms).toMatchObject({
+      string: {
+        concat: expect.any(Function)
+      },
+      number: {
+        increment: expect.any(Function)
+      },
+      boolean: {
+        toggle: expect.any(Function)
+      }
+    });
+    expect(ms.valueOf()).toBe(value);
+  });
+
+  it("allows to transition shallow composed object", () => {
+    let incremented = from({ counter: 42 }).counter.increment();
+    expect(incremented.state).toEqual({ counter: 43 });
+  });
+
+  it("allows to transition deeply composed object", () => {
+    let toggled = from({ a: { b: { c: true } } }).a.b.c.toggle();
+    expect(toggled.state).toMatchObject({ a: { b: { c: false } } });
+  });
+
+  // it("builds microstate for an array of primitive values", () => {
+  //   let value = [true, "hello world", 42];
+  //   let ms = from(value);
+  //   expect(ms).toMatchObject([
+  //     { toggle: expect.any(Function) },
+  //     { concat: expect.any(Function) },
+  //     { increment: expect.any(Function) }
+  //   ]);
+  //   expect(ms.valueOf()).toBe(value);
+  // });
 });

--- a/tests/microstate.test.js
+++ b/tests/microstate.test.js
@@ -89,23 +89,49 @@ describe("from", () => {
   });
 
   it("allows to transition shallow composed object", () => {
-    let incremented = from({ counter: 42 }).counter.increment();
+    let original = { counter: 42 };
+    let incremented = from(original).counter.increment();
+    expect(original).toEqual({ counter: 42 });
     expect(incremented.state).toEqual({ counter: 43 });
   });
 
   it("allows to transition deeply composed object", () => {
-    let toggled = from({ a: { b: { c: true } } }).a.b.c.toggle();
+    let original = { a: { b: { c: true } } };
+    let toggled = from(original).a.b.c.toggle();
+    expect(original).toEqual({ a: { b: { c: true } } });
     expect(toggled.state).toMatchObject({ a: { b: { c: false } } });
   });
 
-  // it("builds microstate for an array of primitive values", () => {
-  //   let value = [true, "hello world", 42];
-  //   let ms = from(value);
-  //   expect(ms).toMatchObject([
-  //     { toggle: expect.any(Function) },
-  //     { concat: expect.any(Function) },
-  //     { increment: expect.any(Function) }
-  //   ]);
-  //   expect(ms.valueOf()).toBe(value);
-  // });
+  let value = [true, "hello world", 42];
+  let shallowArray = from(value);
+
+  it("builds microstate for an array of primitive values", () => {
+    expect(shallowArray).toMatchObject({
+      0: { toggle: expect.any(Function) },
+      1: { concat: expect.any(Function) },
+      2: { increment: expect.any(Function) }
+    });
+    expect(shallowArray.valueOf()).toBe(value);
+  });
+
+  it.only("allows to transition a primitive value in shallow array", () => {
+    expect(shallowArray[0].toggle().valueOf()).toEqual([
+      false,
+      "hello world",
+      42
+    ]);
+    expect(value).toEqual([true, "hello world", 42]);
+    expect(shallowArray[1].concat("!!!").valueOf()).toEqual([
+      true,
+      "hello world!!!",
+      42
+    ]);
+    expect(value).toEqual([true, "hello world", 42]);
+    expect(shallowArray[2].increment().valueOf()).toEqual([
+      false,
+      "hello world",
+      43
+    ]);
+    expect(value).toEqual([true, "hello world", 42]);
+  });
 });

--- a/tests/microstate.test.js
+++ b/tests/microstate.test.js
@@ -38,7 +38,7 @@ describe("from", () => {
   it("makes a number to microstate", () => {
     let ms = from(42);
     expect(ms).toMatchObject({
-      increment: expect.any(Function)
+      increment: expect.any(Function),
     });
     expect(ms.state).toBe(42);
     expect(ms.valueOf()).toBe(42);
@@ -47,7 +47,7 @@ describe("from", () => {
   it("makes a boolean into a microstate", () => {
     let ms = from(true);
     expect(ms).toMatchObject({
-      toggle: expect.any(Function)
+      toggle: expect.any(Function),
     });
     expect(ms.state).toBe(true);
     expect(ms.valueOf()).toBe(true);
@@ -56,7 +56,7 @@ describe("from", () => {
   it("makes a string into a microstate", () => {
     let ms = from("hello world");
     expect(ms).toMatchObject({
-      concat: expect.any(Function)
+      concat: expect.any(Function),
     });
     expect(ms.state).toBe("hello world");
     expect(ms.valueOf()).toBe("hello world");
@@ -76,14 +76,14 @@ describe("from", () => {
     let ms = from(value);
     expect(ms).toMatchObject({
       string: {
-        concat: expect.any(Function)
+        concat: expect.any(Function),
       },
       number: {
-        increment: expect.any(Function)
+        increment: expect.any(Function),
       },
       boolean: {
-        toggle: expect.any(Function)
-      }
+        toggle: expect.any(Function),
+      },
     });
     expect(ms.valueOf()).toBe(value);
   });
@@ -109,29 +109,34 @@ describe("from", () => {
     expect(shallowArray).toMatchObject({
       0: { toggle: expect.any(Function) },
       1: { concat: expect.any(Function) },
-      2: { increment: expect.any(Function) }
+      2: { increment: expect.any(Function) },
     });
     expect(shallowArray.valueOf()).toBe(value);
   });
 
-  it.only("allows to transition a primitive value in shallow array", () => {
-    expect(shallowArray[0].toggle().valueOf()).toEqual([
-      false,
-      "hello world",
-      42
-    ]);
+  it("allows to transition a primitive value in shallow array", () => {
+    let toggled = shallowArray[0].toggle();
+    expect(toggled.valueOf()).toEqual([false, "hello world", 42]);
     expect(value).toEqual([true, "hello world", 42]);
-    expect(shallowArray[1].concat("!!!").valueOf()).toEqual([
-      true,
-      "hello world!!!",
-      42
-    ]);
+
+    let longer = shallowArray[1].concat("!!!");
+    expect(longer.valueOf()).toEqual([true, "hello world!!!", 42]);
     expect(value).toEqual([true, "hello world", 42]);
-    expect(shallowArray[2].increment().valueOf()).toEqual([
-      false,
-      "hello world",
-      43
-    ]);
+
+    let incremented = shallowArray[2].increment();
+    expect(incremented.valueOf()).toEqual([true, "hello world", 43]);
     expect(value).toEqual([true, "hello world", 42]);
+  });
+
+  it("allows to transition an array with deeply nested objects", () => {
+    let value = [{ a: { b: { c: true } } }];
+    let toggled = from(value)[0].a.b.c.toggle();
+    expect(toggled.valueOf()).toEqual([{ a: { b: { c: false } } }]);
+  });
+
+  it("allows to transition an array composed into an array", () => {
+    let value = [[[ true ]]];
+    let toggled = from(value)[0][0][0].toggle();
+    expect(toggled.valueOf()).toEqual([[[false]]]);
   });
 });


### PR DESCRIPTION
`Microstate.create` allows to build an instance of a microstate from a Type and a value. Microstates will use this `Type` to build a data structure with all of its transitions and state. This works great when the data structure is known ahead of time and you use it enough to warrant declaring the structure of your data before calling `Microstate.create`. 

What if you have a POJO that you need to transition but you don't have its type? 

Before this PR, you were out of luck. This PR introducing `Microstate.from` which takes a value and builds a microstate that you can call transitions on. `Microstate.from` doesn't currently have any way to match custom types from your application but it can detect primitive values and provide transitions for that type.

For example, you can do

```js
import { from } from 'microstate';

from(42).increment().valueOf();
// => 43

from(true).toggle();
// => false

from('hello world').concat('!!!');
// => hello world!!!
```

You can also pass deeply nested POJOs.

```js
from({ a: { b: { c: 42 } } }).a.b.c.increment().valueOf();
// => { a: { b: { c: 42 } } }
```

You can do,

```js
from([[[false]]])[0][0][0].toggle().valueOf();
// => [[[true]]]
```

You can even combine them in whatever way you want,

```js
let incremented = from({
  products: [
    { title: "Legos" 
       blocks: [
         {shape: 'square', quantity: 20}
       ]
     },
  ]
}).products[0].blocks[0].quantity.increment();

incremented.valueOf();
// = > {
//  products: [
//    { title: "Legos" 
//       blocks: [
//         {shape: 'square', quantity: 21}
//       ]
//     },
//  ]
//}
```