### PR TITLE
Make sure that state getter is only evaluted once for a microstate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ node_js:
   - "6"
 
 install:
-  - npm i -g coveralls
+  - npm install -g npm@latest
+  - npm install -g coveralls
   - npm install
 
 script:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "microstates",
-  "version": "0.5.2",
+  "version": "0.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3729,15 +3729,6 @@
         }
       }
     },
-    "funcadelic": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/funcadelic/-/funcadelic-0.3.2.tgz",
-      "integrity": "sha1-4XiC1b10PM6H8kJuECACQnPqUpM=",
-      "requires": {
-        "lodash.curry": "4.1.1",
-        "object.getownpropertydescriptors": "2.0.3"
-      }
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -5326,11 +5317,6 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
-    },
-    "lodash.curry": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
-      "integrity": "sha1-JI42By7ekGUB11lmIAqG2riyMXA="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "start": "npm test -- --watch"
   },
   "dependencies": {
-    "funcadelic": "^0.3.2",
+    "funcadelic": "0.3.3",
     "object.getownpropertydescriptors": "2.0.3",
-    "ramda": "^0.25.0",
+    "ramda": "0.25.0",
     "symbol-observable": "1.2.0"
   },
   "devDependencies": {

--- a/src/desugar.js
+++ b/src/desugar.js
@@ -3,14 +3,14 @@ import { parameterized } from '../src/types';
 import { values } from './typeclasses/values';
 import { map } from 'funcadelic';
 
-let ContainsTypes = Monoid.create(class ContainsTypes {
+export const ContainsTypes = Monoid.create(class ContainsTypes {
   empty() { return true; }
   append(a, b) {
     return a && (b instanceof Function || isSugar(b));
   }
 });
 
-function isPossibleSugar(Type) {
+export function isPossibleSugar(Type) {
   return Type && (Type.constructor === Array || Type.constructor === Object);
 }
 

--- a/src/structure.js
+++ b/src/structure.js
@@ -10,6 +10,8 @@ import isSimple  from './is-simple';
 import desugar from './desugar';
 import Microstate from './microstate';
 import { collapse } from './typeclasses/collapse';
+import getPrototypeDescriptors from './utils/get-prototype-descriptors';
+import thunk from './thunk';
 
 const { assign } = Object;
 
@@ -142,6 +144,16 @@ function graft(path, tree) {
   }
 }
 
+function cachedGetters(Type) {
+  let descriptors = $(getPrototypeDescriptors(Type))
+    .filter(({ value }) => !!value.get)
+    .map(descriptor => append(descriptor, {
+      get: thunk(descriptor.get)
+    }))
+    .valueOf();
+  return Object.create(Type.prototype, descriptors);
+}
+
 class Node {
   constructor(Type, path) {
     assign(this, { Type, path });
@@ -162,7 +174,7 @@ class Node {
     if (isSimple(Type)) {
       return valueAt || instance;
     } else {
-      return stateAt(Type, instance, valueAt);
+      return stateAt(Type, append(instance, cachedGetters(Type)), valueAt);
     }
   }
 

--- a/src/thunk.js
+++ b/src/thunk.js
@@ -5,7 +5,7 @@ export default function thunk(fn) {
     if (evaluated) {
       return result;
     } else {
-      result = fn();
+      result = fn.call(this);
       evaluated = true;
       return result;
     }

--- a/tests/state.test.js
+++ b/tests/state.test.js
@@ -4,6 +4,7 @@ import { parameterized } from '../src/types/parameters';
 import analyze from '../src/structure';
 import { map } from 'funcadelic';
 import { collapse } from '../src/typeclasses/collapse';
+import { create } from 'microstates';
 
 function node(Type, value) {
   return analyze(Type, value).data;
@@ -42,6 +43,13 @@ describe('State', () => {
       expect(state.firstName).toEqual('Charles');
       expect(state.lastName).toEqual('Lowell');
       expect(state.fullName).toEqual('Charles Lowell');
+    });
+  });
+
+  describe('reading state twice', () => {
+    it('returns the same root state', () => {
+      let ms = create(User);
+      expect(ms.state).toBe(ms.state);
     });
   });
 });

--- a/tests/state.test.js
+++ b/tests/state.test.js
@@ -47,9 +47,16 @@ describe('State', () => {
   });
 
   describe('reading state twice', () => {
+    class Node {
+      node = Node
+    }
+    let ms = create(Node);
     it('returns the same root state', () => {
-      let ms = create(User);
       expect(ms.state).toBe(ms.state);
+    });
+    it('returns the same node when composed state is read twice', () => {
+      expect(ms.state.node).toBe(ms.state.node);
+      expect(ms.state.node.node).toBe(ms.state.node.node);
     });
   });
 });

--- a/tests/state.test.js
+++ b/tests/state.test.js
@@ -46,17 +46,34 @@ describe('State', () => {
     });
   });
 
-  describe('reading state twice', () => {
-    class Node {
-      node = Node
-    }
-    let ms = create(Node);
-    it('returns the same root state', () => {
-      expect(ms.state).toBe(ms.state);
+  describe('stability', () => {
+
+    describe('reading state root', () => {
+      class Node {
+        node = Node
+      }
+      let ms = create(Node);
+      it('returns the same root state', () => {
+        expect(ms.state).toBe(ms.state);
+      });
+      it('returns the same node when composed state is read twice', () => {
+        expect(ms.state.node).toBe(ms.state.node);
+        expect(ms.state.node.node).toBe(ms.state.node.node);
+      });
     });
-    it('returns the same node when composed state is read twice', () => {
-      expect(ms.state.node).toBe(ms.state.node);
-      expect(ms.state.node.node).toBe(ms.state.node.node);
+    
+    describe('reading getters', () => {
+      class Node {
+        node = Node;
+  
+        get data() {
+          return {};
+        }
+      }
+      it('returns same value', () => {
+        let ms = create(Node);
+        expect(ms.state.data).toBe(ms.state.data);
+      });
     });
   });
 });

--- a/tests/sugar.test.js
+++ b/tests/sugar.test.js
@@ -1,77 +1,102 @@
 import 'jest';
 
-import desugar, { isSugar } from '../src/desugar';
+import desugar, { isSugar, ContainsTypes, isPossibleSugar } from '../src/desugar';
 import types, { params } from '../src/types';
 import { any } from '../src/types/parameters';
 
-it('detects [] as sugar', () => {
-  expect(isSugar([])).toBe(true);
-});
-
-it('detects {} as sugar', () => {
-  expect(isSugar({})).toBe(true);
-});
-
-it('detects [Type] as sugar', () => {
-  expect(isSugar([Boolean])).toBe(true);
-  expect(isSugar([class Item {}])).toBe(true);
-});
-
-it('detects {Type} as sugar', () => {
-  expect(isSugar({Boolean})).toBe(true);
-});
-
-it('detects {[Number]} as sugar', function() {
-  let Numbers = [Number];
-  expect(isSugar({Numbers})).toBe(true);
-});
-
-it('detects [[Number]] as sugar', function() {
-  expect(isSugar([[Number]])).toBe(true);
-});
-
-it('converts [] into parameterized(Array)', () => {
-  let Parameterized = desugar([]);
-  expect(Parameterized.prototype).toBeInstanceOf(types.Array);
-  expect(params(Parameterized).T).toBe(any);
-});
-
-it('converts [Type] into parameterized(Array, Type)', () => {
-  let Parameterized = desugar([Boolean]);
-  expect(Parameterized.prototype).toBeInstanceOf(types.Array);
-  expect(params(Parameterized).T).toBe(types.Boolean);
-});
-
-it('converts {} into parameterized(Object)', () => {
-  let Parameterized = desugar({});
-  expect(Parameterized.prototype).toBeInstanceOf(types.Object);
-  expect(params(Parameterized).T).toBe(any);
-});
-
-it('converts {Type} into parameterized(Object, Type)', () => {
-  let Parameterized = desugar({Boolean});
-  expect(Parameterized.prototype).toBeInstanceOf(types.Object);
-  expect(params(Parameterized).T).toBe(types.Boolean);
-});
-
-it('converts {[Number]} into parameterized(Object, parameterized(Array, Number))', function() {
-  let Numbers = [Number];
+describe('isSugar', () => {
+  it('Array is not sugar', () => {
+    expect(isSugar(Array)).toBe(false);
+  });
   
-  let Parameterized = desugar({Numbers});
-  expect(Parameterized.prototype).toBeInstanceOf(types.Object);
+  it('Object is not sugar', () => {
+    expect(isSugar(Object)).toBe(false);
+  });
   
-  let { T } = params(Parameterized);
-  expect(T.prototype).toBeInstanceOf(types.Array);
+  it('detects [] as sugar', () => {
+    expect(isSugar([])).toBe(true);
+  });
+  
+  it('detects {} as sugar', () => {
+    expect(isSugar({})).toBe(true);
+  });
+  
+  it('detects [Type] as sugar', () => {
+    expect(isSugar([Boolean])).toBe(true);
+    expect(isSugar([class Item {}])).toBe(true);
+  });
+  
+  it('detects {Type} as sugar', () => {
+    expect(isSugar({Boolean})).toBe(true);
+  });
+  
+  it('detects {[Number]} as sugar', function() {
+    let Numbers = [Number];
+    expect(isSugar({Numbers})).toBe(true);
+  });
+  
+  it('detects [[Number]] as sugar', function() {
+    expect(isSugar([[Number]])).toBe(true);
+  });
+})
 
-  expect(params(T).T).toBe(types.Number);
+describe('desugar', () => {
+  it('passes Array through without modification', () => {
+    expect(desugar(Array)).toBe(Array);
+  });
+  
+  it('converts [] into parameterized(Array)', () => {
+    let Parameterized = desugar([]);
+    expect(Parameterized.prototype).toBeInstanceOf(types.Array);
+    expect(params(Parameterized).T).toBe(any);
+  });
+  
+  it('converts [Type] into parameterized(Array, Type)', () => {
+    let Parameterized = desugar([Boolean]);
+    expect(Parameterized.prototype).toBeInstanceOf(types.Array);
+    expect(params(Parameterized).T).toBe(types.Boolean);
+  });
+  
+  it('converts {} into parameterized(Object)', () => {
+    let Parameterized = desugar({});
+    expect(Parameterized.prototype).toBeInstanceOf(types.Object);
+    expect(params(Parameterized).T).toBe(any);
+  });
+  
+  it('converts {Type} into parameterized(Object, Type)', () => {
+    let Parameterized = desugar({Boolean});
+    expect(Parameterized.prototype).toBeInstanceOf(types.Object);
+    expect(params(Parameterized).T).toBe(types.Boolean);
+  });
+  
+  it('converts {[Number]} into parameterized(Object, parameterized(Array, Number))', function() {
+    let Numbers = [Number];
+    
+    let Parameterized = desugar({Numbers});
+    expect(Parameterized.prototype).toBeInstanceOf(types.Object);
+    
+    let { T } = params(Parameterized);
+    expect(T.prototype).toBeInstanceOf(types.Array);
+  
+    expect(params(T).T).toBe(types.Number);
+  });
+  
+  it('converts [[Number]] into parameterized(Array, parameterized(Array, Number))', function() {
+    let Parameterized = desugar([[Number]]);
+    expect(Parameterized.prototype).toBeInstanceOf(types.Array);
+  
+    let { T } = params(Parameterized);
+    expect(T.prototype).toBeInstanceOf(types.Array);
+  
+    expect(params(T).T).toBe(types.Number);
+  });
 });
 
-it('converts [[Number]] into parameterized(Array, parameterized(Array, Number))', function() {
-  let Parameterized = desugar([[Number]]);
-  expect(Parameterized.prototype).toBeInstanceOf(types.Array);
-
-  let { T } = params(Parameterized);
-  expect(T.prototype).toBeInstanceOf(types.Array);
-
-  expect(params(T).T).toBe(types.Number);
+describe('isPossibleSugar', () => {
+  it('result false for String', () => {
+    expect(isPossibleSugar(String)).toBe(false);
+  });
+  it('returns true for [String]', () => {
+    expect(isPossibleSugar([String])).toBe(true);
+  });
 });


### PR DESCRIPTION
This is a "low hanging fruit" type improvement that ensures the state getter value is changed for any microstate. This is to ensure that same microstate doesn't generate multiple instances of composed state at same path. This PR also add caching to getters.