### PR TITLE
Ensure value from `static create` is provided to composed children

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6775,8 +6775,7 @@
     "stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
-      "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
-      "dev": true
+      "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA="
     },
     "staged-git-files": {
       "version": "0.0.4",

--- a/src/microstate.js
+++ b/src/microstate.js
@@ -28,7 +28,6 @@ export default class Microstate {
    */
   get state() {
     let { tree, value } = reveal(this);
-
     return collapseState(tree, value);
   }
 

--- a/src/microstate.js
+++ b/src/microstate.js
@@ -4,7 +4,6 @@ import { keep, reveal } from "./utils/secret";
 import SymbolObservable from "symbol-observable";
 import { collapse } from './typeclasses/collapse';
 import State from './typeclasses/state';
-import logTree from './utils/log-tree';
 
 export default class Microstate {
   constructor(tree, value) {

--- a/src/microstate.js
+++ b/src/microstate.js
@@ -1,7 +1,9 @@
 import { map } from "funcadelic";
-import analyze, { collapseState } from "./structure";
+import analyze from "./structure";
 import { keep, reveal } from "./utils/secret";
 import SymbolObservable from "symbol-observable";
+import { collapse } from './typeclasses/collapse';
+import State from './typeclasses/state';
 
 export default class Microstate {
   constructor(tree, value) {
@@ -28,7 +30,7 @@ export default class Microstate {
    */
   get state() {
     let { tree, value } = reveal(this);
-    return collapseState(tree, value);
+    return collapse(new State(tree, value));
   }
 
   /**

--- a/src/microstate.js
+++ b/src/microstate.js
@@ -4,6 +4,7 @@ import { keep, reveal } from "./utils/secret";
 import SymbolObservable from "symbol-observable";
 import { collapse } from './typeclasses/collapse';
 import State from './typeclasses/state';
+import logTree from './utils/log-tree';
 
 export default class Microstate {
   constructor(tree, value) {

--- a/src/microstate.js
+++ b/src/microstate.js
@@ -17,11 +17,10 @@ export default class Microstate {
    * this value.
    *
    * @param {*} Type
-   * @param {*} value
+   * @param {*} initialValue
    */
-  static create(Type, value) {
-    value = value != null ? value.valueOf() : value;
-    let tree = analyze(Type, value);
+  static create(Type, initialValue) {
+    let { tree, value } = analyze(Type, initialValue);
     return new Microstate(tree, value);
   }
 

--- a/src/structure.js
+++ b/src/structure.js
@@ -10,6 +10,7 @@ import isSimple  from './is-simple';
 import desugar from './desugar';
 import Microstate from './microstate';
 import { collapse } from './typeclasses/collapse';
+import truncate from './truncate';
 
 const { assign } = Object;
 
@@ -44,7 +45,7 @@ function analyzeType(value) {
         let childTypes = childrenAt(Type, node.valueAt(value));
         
         return map((ChildType, path) => {
-          
+
           let child = node.isShifted ? 
             new ShiftNode({Type: ChildType, path: append(node.path, path)}, view(lensPath([path]), node.valueAt())) : 
             new Node(ChildType, append(node.path, path));
@@ -85,7 +86,7 @@ Location.instance(Object, {
 });
 
 Location.instance(types.Object, {
-  stateAt: _ => {},
+  stateAt: _ => ({}),
   childrenAt(Type, value) {
     let { T } = params(Type);
     if (T !== any) {
@@ -102,17 +103,6 @@ Location.instance(types.Array, {
     return Location.for(types.Object.prototype).childrenAt(...args);
   }
 });
-
-function truncate(fn, tree) {
-  return flatMap(node => {
-    let subtree = view(lensTree(node.path), tree);
-    if (fn(subtree.data)) {
-      return append(subtree, { children: [] });
-    } else {
-      return subtree;
-    }
-  }, tree);
-}
 
 class Node {
   constructor(Type, path) {

--- a/src/structure.js
+++ b/src/structure.js
@@ -34,8 +34,9 @@ function analyzeType(value) {
     if (instance instanceof Microstate) {
       let { tree , value } = reveal(instance);
 
-      // when type shifting a node with a new value, the new value needs to be shifted
-      // into every child not just the shifted node.
+      // when type shifting a node with a new value, 
+      // the new value needs to be shifted into every child,
+      // not just the shifted node.
       return graft(node.path, map(node => new ShiftNode(node, view(lensPath(node.path), value)), tree));
     }
 
@@ -46,9 +47,11 @@ function analyzeType(value) {
         
         return map((ChildType, path) => {
 
+          let childPath = append(node.path, path);
+
           let child = node.isShifted ? 
-            new ShiftNode({Type: ChildType, path: append(node.path, path)}, view(lensPath([path]), node.valueAt())) : 
-            new Node(ChildType, append(node.path, path));
+            new ShiftNode({Type: ChildType, path: childPath}, view(lensPath([path]), node.valueAt())) : 
+            new Node(ChildType, childPath);
 
           return pure(Tree, child);
         }, childTypes);

--- a/src/structure.js
+++ b/src/structure.js
@@ -12,7 +12,6 @@ import Microstate from './microstate';
 import { collapse } from './typeclasses/collapse';
 import truncate from './truncate';
 import Value from './typeclasses/value';
-import logTree from './utils/log-tree';
 
 const { assign } = Object;
 

--- a/src/structure.js
+++ b/src/structure.js
@@ -29,14 +29,20 @@ function analyzeType(value) {
     let Type = toType(InitialType);
 
     let instance = Type.hasOwnProperty('create') ? Type.create(valueAt) : undefined;
-
+    
     if (instance instanceof Microstate) {
       let { tree , value } = reveal(instance);
 
+      // when type shifting a node with a new value, the new value needs to be shifted
+      // into every child not just the shifted node.
       let shift = new ShiftNode(tree.data, value);
       return graft(node.path, new Tree({
         data: () => shift,
-        children: () => tree.children
+        children: () => map(tree => {
+          return map(node => {
+            return new ShiftNode(node, view(lensPath(node.path), value));
+          }, tree);
+        }, tree.children)
       }));
     }
 

--- a/src/structure.js
+++ b/src/structure.js
@@ -1,5 +1,5 @@
 import $ from './utils/chain';
-import { type, map, append, pure, foldr } from 'funcadelic';
+import { type, map, append, pure } from 'funcadelic';
 import { flatMap } from './monad';
 import { view, set, lensTree, lensPath } from './lens';
 import Tree, { graft, prune } from './utils/tree';
@@ -15,10 +15,8 @@ import Value from './typeclasses/value';
 
 const { assign } = Object;
 
-let valueOf = value => value != null ? value.valueOf() : value;
-
 export default function analyze(Type, value) {
-  value = valueOf(value);
+  value = value ? value.valueOf() : value;
 
   let tree = flatMap(analyzeType(value), pure(Tree, new Node(Type, [])));
 

--- a/src/structure.js
+++ b/src/structure.js
@@ -37,12 +37,20 @@ function analyzeType(value) {
       // into every child not just the shifted node.
       return graft(node.path, map(node => new ShiftNode(node, view(lensPath(node.path), value)), tree));
     }
-    
+
     return new Tree({
       data: () => Type === node.Type ? node : append(node, { Type }),
       children() {
         let childTypes = childrenAt(Type, node.valueAt(value));
-        return map((ChildType, path) => pure(Tree, new Node(ChildType, append(node.path, path))), childTypes);
+        
+        if (node.isShifted) {
+          return map((ChildType, path) => {
+            let shift = new ShiftNode({Type: ChildType, path: append(node.path, path)}, view(lensPath([path]), node.valueAt()));
+            return pure(Tree, shift);
+          }, childTypes);
+        } else {
+          return map((ChildType, path) => pure(Tree, new Node(ChildType, append(node.path, path))), childTypes)
+        }
       }
     });
   };

--- a/src/structure.js
+++ b/src/structure.js
@@ -18,11 +18,6 @@ export default function analyze(Type, value) {
   return flatMap(analyzeType(value), pure(Tree, new Node(Type, [])));
 }
 
-export function collapseState(tree, value) {
-  let truncated = truncate(node => node.isSimple, tree);
-  return collapse(map(node => node.stateAt(value), truncated));
-}
-
 function analyzeType(value) {
   return (node) => {
     let InitialType = desugar(node.Type);

--- a/src/structure.js
+++ b/src/structure.js
@@ -12,6 +12,7 @@ import Microstate from './microstate';
 import { collapse } from './typeclasses/collapse';
 import truncate from './truncate';
 import Value from './typeclasses/value';
+import logTree from './utils/log-tree';
 
 const { assign } = Object;
 
@@ -22,10 +23,14 @@ export default function analyze(Type, value) {
 
   let tree = flatMap(analyzeType(value), pure(Tree, new Node(Type, [])));
 
+  // this happens when a type-shift is performed with `static create` function
+  // we need to combined the returned values to make sure that they are available
+  // for a transition to happen.  
   if (tree.data.isShifted) {
-    let collapsed = collapse(new Value(tree, value));
-    let unshifted = map(node => node.isShifted ? new Node(node.Type, node.path) : node, tree);  
-    return { tree: unshifted, value: collapsed };
+    return { 
+      tree: map(node => node.isShifted ? new Node(node.Type, node.path) : node, tree),
+      value: collapse(new Value(tree, value))
+    };
   } else {
     return { tree, value };
   }

--- a/src/structure.js
+++ b/src/structure.js
@@ -35,9 +35,8 @@ function analyzeType(value) {
 
       // when type shifting a node with a new value, the new value needs to be shifted
       // into every child not just the shifted node.
-      let shift = new ShiftNode(tree.data, value);
       return graft(node.path, new Tree({
-        data: () => shift,
+        data: () => new ShiftNode(tree.data, value),
         children: () => map(tree => {
           return map(node => {
             return new ShiftNode(node, view(lensPath(node.path), value));
@@ -45,7 +44,7 @@ function analyzeType(value) {
         }, tree.children)
       }));
     }
-
+    
     return new Tree({
       data: () => Type === node.Type ? node : append(node, { Type }),
       children() {
@@ -169,6 +168,10 @@ class ShiftNode extends Node {
   constructor({ Type, path }, value) {
     super(Type, path);
     assign(this, { value });
+  }
+
+  get isShifted() {
+    return true;
   }
 
   valueAt() {

--- a/src/structure.js
+++ b/src/structure.js
@@ -43,14 +43,14 @@ function analyzeType(value) {
       children() {
         let childTypes = childrenAt(Type, node.valueAt(value));
         
-        if (node.isShifted) {
-          return map((ChildType, path) => {
-            let shift = new ShiftNode({Type: ChildType, path: append(node.path, path)}, view(lensPath([path]), node.valueAt()));
-            return pure(Tree, shift);
-          }, childTypes);
-        } else {
-          return map((ChildType, path) => pure(Tree, new Node(ChildType, append(node.path, path))), childTypes)
-        }
+        return map((ChildType, path) => {
+          
+          let child = node.isShifted ? 
+            new ShiftNode({Type: ChildType, path: append(node.path, path)}, view(lensPath([path]), node.valueAt())) : 
+            new Node(ChildType, append(node.path, path));
+
+          return pure(Tree, child);
+        }, childTypes);
       }
     });
   };

--- a/src/structure.js
+++ b/src/structure.js
@@ -147,7 +147,7 @@ class Node {
 
       let nextTree = set(lensTree(path), graft(path, nextLocalTree), tree);
       let nextValue = set(lensPath(path), nextLocalValue, value);
-
+      
       return { tree: nextTree, value: nextValue };
     }, transitionsFor(Type));
   }

--- a/src/structure.js
+++ b/src/structure.js
@@ -15,7 +15,9 @@ import truncate from './truncate';
 const { assign } = Object;
 
 export default function analyze(Type, value) {
-  return flatMap(analyzeType(value), pure(Tree, new Node(Type, [])));
+  value = value != null ? value.valueOf() : value;  
+  let tree = flatMap(analyzeType(value), pure(Tree, new Node(Type, [])));
+  return { tree, value };
 }
 
 function analyzeType(value) {

--- a/src/structure.js
+++ b/src/structure.js
@@ -35,14 +35,7 @@ function analyzeType(value) {
 
       // when type shifting a node with a new value, the new value needs to be shifted
       // into every child not just the shifted node.
-      return graft(node.path, new Tree({
-        data: () => new ShiftNode(tree.data, value),
-        children: () => map(tree => {
-          return map(node => {
-            return new ShiftNode(node, view(lensPath(node.path), value));
-          }, tree);
-        }, tree.children)
-      }));
+      return graft(node.path, map(node => new ShiftNode(node, view(lensPath(node.path), value)), tree));
     }
     
     return new Tree({

--- a/src/truncate.js
+++ b/src/truncate.js
@@ -1,0 +1,14 @@
+import { append } from 'funcadelic';
+import { flatMap } from './monad';
+import { view, lensTree } from './lens';
+
+export default function truncate(fn, tree) {
+  return flatMap(node => {
+    let subtree = view(lensTree(node.path), tree);
+    if (fn(subtree.data)) {
+      return append(subtree, { children: [] });
+    } else {
+      return subtree;
+    }
+  }, tree);
+}

--- a/src/typeclasses.js
+++ b/src/typeclasses.js
@@ -23,7 +23,9 @@ Functor.instance(Microstate, {
 
     // tree of transitions
     let next = map(node => {
+      
       let transitions = node.transitionsAt(value, tree, invoke);
+
       return map(transition => {
         return (...args) => {
           let { tree, value } = transition(...args);

--- a/src/typeclasses.js
+++ b/src/typeclasses.js
@@ -10,7 +10,6 @@ import truncate from './truncate';
 import State from './typeclasses/state';
 import Value from './typeclasses/value';
 import types from './types';
-import logTree from './utils/log-tree';
 import getDescriptors from 'object.getownpropertydescriptors';
 
 const { keys, getPrototypeOf } = Object;
@@ -61,8 +60,7 @@ Collapse.instance(Tree, {
 Collapse.instance(State, {
   collapse({ tree, value }) {
     let truncated = truncate(node => node.isSimple, tree);
-    let state = map(node => node.stateAt(value), truncated);
-    return collapse(state); 
+    return collapse(map(node => node.stateAt(value), truncated)); 
   }
 });
 

--- a/src/typeclasses.js
+++ b/src/typeclasses.js
@@ -8,8 +8,10 @@ import thunk from './thunk';
 import truncate from './truncate';
 import State from './typeclasses/state';
 import Value from './typeclasses/value';
+import types from './types';
+import logTree from './utils/log-tree';
 
-const { keys } = Object;
+const { keys, getPrototypeOf } = Object;
 
 function invoke({ method, args, value, tree}) {
   let nextValue = method.apply(new Microstate(tree, value), args);
@@ -63,8 +65,8 @@ Collapse.instance(State, {
 
 Collapse.instance(Value, {
   collapse({ tree, value }) {
-    let truncated = truncate(node => node.isSimple || node.isShifted, tree);
-    return collapse(map(node => node.valueAt(value), truncated));
+    let truncated = truncate(node => node.isSimple || node.valueAt(value) === undefined, tree);
+    return collapse(map(node => getPrototypeOf(node.Type) === types.Array ? [] : node.valueAt(value), truncated));
   }
 });
 

--- a/src/typeclasses/state.js
+++ b/src/typeclasses/state.js
@@ -1,0 +1,6 @@
+export default class State {
+  constructor(tree, value) {
+    this.tree = tree;
+    this.value = value;
+  }
+}

--- a/src/typeclasses/value.js
+++ b/src/typeclasses/value.js
@@ -1,0 +1,6 @@
+export default class Value {
+  constructor(tree, value) {
+    this.tree = tree;
+    this.value = value;
+  }
+}

--- a/src/utils/log-tree.js
+++ b/src/utils/log-tree.js
@@ -2,20 +2,24 @@ import { map, append, foldl } from 'funcadelic';
 
 export function visualize(tree, value, level = 0) {
   let node = tree.data;
-  let { Type, path } = node;
-  // puts '| | | ' before a line to denote how deep in the tree it is
-  let preamble = Array(level).fill(0).map(() => '|  ').join('');
-
-  // render the line for this child
-  let lines = [`${preamble}${path.length ? path[path.length - 1]: 'root'} :: ${JSON.stringify({ Type: Type.name, path, value: node.valueAt(value) })}`];
-
-  // convert all children into arrays
-  let children = tree.children instanceof Array ? tree.children : Object.values(tree.children);
-  // render the lines for the children.
-  let childLines = map(child => visualize(child, value, level + 1), children);
-
-  // flatten the child lines into a single array (insted of an array of arrays)
-  return lines.concat(foldl((lines, l) => lines.concat(l), [], childLines));
+  if (node.Type && node.path) {
+    let { Type, path } = node;
+    // puts '| | | ' before a line to denote how deep in the tree it is
+    let preamble = Array(level).fill(0).map(() => '|  ').join('');
+  
+    // render the line for this child
+    let lines = [`${preamble}${path.length ? path[path.length - 1]: 'root'} :: ${JSON.stringify({ Type: Type.name, path, value: node.valueAt(value) })}`];
+  
+    // convert all children into arrays
+    let children = tree.children instanceof Array ? tree.children : Object.values(tree.children);
+    // render the lines for the children.
+    let childLines = map(child => visualize(child, value, level + 1), children);
+  
+    // flatten the child lines into a single array (insted of an array of arrays)
+    return lines.concat(foldl((lines, l) => lines.concat(l), [], childLines));
+  } else {
+    return [JSON.stringify(node)];
+  }
 }
 export default function logTree(tree, value) {
   console.log(visualize(tree, value).join("\n"));

--- a/tests/microstate.parameterized.test.js
+++ b/tests/microstate.parameterized.test.js
@@ -37,19 +37,26 @@ describe("Parameterized Microstates: ", () => {
     describe("root {[Number]} to parameterized(Object, parameterized(Array, Number))", function() {
       let Numbers = [Number];
       let Counters = { Numbers };
-      let m, value;
+      let m, value, transitioned;
       beforeEach(function() {
         value = {
           oranges: [50, 20],
           apples: [1, 2, 45]
         };
         m = create(Counters, value);
+        transitioned = m.apples[0].increment().oranges[1].increment();
       });
       it("uses the same value for state as the value ", function() {
         expect(m.state).toEqual(m.valueOf());
       });
-      it("still respects transitions", function() {
-        expect(m.apples[0].increment().oranges[1].increment().state).toEqual({
+      it("computed value for transitioned", () => {
+        expect(transitioned.valueOf()).toEqual({
+          oranges: [50, 21],
+          apples: [2, 2, 45]
+        });
+      });
+      it("computed state for transitioned", function() {        
+        expect(transitioned.state).toEqual({
           oranges: [50, 21],
           apples: [2, 2, 45]
         });

--- a/tests/observable-test.js
+++ b/tests/observable-test.js
@@ -109,3 +109,24 @@ describe("complex type", function() {
     });
   });
 });
+
+describe('initialized microstate', () => {
+  class Modal {
+    isOpen = Boolean;
+
+    static create(value) {
+      if (!value) {
+        return create(Modal, { isOpen: true });
+      }
+    }
+  }
+
+  it('streams initialized microstate', () => {
+    let fn = jest.fn();
+    Observable.from(create(Modal)).subscribe(fn);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn.mock.calls[0][0].state).toMatchObject({
+      isOpen: true
+    });
+  });
+});

--- a/tests/state.test.js
+++ b/tests/state.test.js
@@ -6,7 +6,8 @@ import { map } from 'funcadelic';
 import { collapse } from '../src/typeclasses/collapse';
 
 function node(Type, value) {
-  return analyze(Type, value).data;
+  let { tree } = analyze(Type, value);
+  return tree.data;
 }
 
 class User {
@@ -36,7 +37,7 @@ describe('State', () => {
   });
   describe('of a non-simple type', function() {
     it('is an instance of that type', function() {
-      let tree = analyze(User, {firstName: 'Charles', lastName: 'Lowell'});
+      let { tree } = analyze(User, {firstName: 'Charles', lastName: 'Lowell'});
       let state = collapse(map(node => node.stateAt({firstName: 'Charles', lastName: 'Lowell'}), tree));
       expect(state).toBeInstanceOf(User);
       expect(state.firstName).toEqual('Charles');

--- a/tests/structure.test.js
+++ b/tests/structure.test.js
@@ -23,7 +23,7 @@ describe('Structure', () => {
     }
   }
   let initialValue = { user: { firstName: 'Charles', lastName: 'Lowell' } };
-  let tree = analyze(Session);
+  let { tree } = analyze(Session);
 
   it('can fetch the value at each node', function() {
     expect(tree.data.valueAt(initialValue)).toMatchObject({
@@ -54,7 +54,7 @@ describe('Structure', () => {
       user: { firstName: 'Authentic Charles', lastName: 'Authentic Lowell'}
     };
 
-    let tree = analyze(Authenticated, returnValue);
+    let { tree } = analyze(Authenticated, returnValue);
 
     let invoke = jest.fn(() => ({
       value: returnValue,
@@ -85,10 +85,7 @@ describe('Structure', () => {
   it('can transition at child nodes', function() {
     class SuperString {}
 
-    let invoke = jest.fn(() => ({
-      tree: analyze(SuperString, 'Super-tastic!'),
-      value: 'Super-tastic!'
-    }));
+    let invoke = jest.fn(() => analyze(SuperString, 'Super-tastic!'));
 
     let { tree: nextTree, value: nextValue } = tree.children.user.children.lastName.data.transitionsAt(initialValue, tree, invoke).set('make super');
 
@@ -114,12 +111,8 @@ describe('Structure', () => {
   });
 
   describe('A Parameterized Array', function() {
-    let array;
-    beforeEach(function() {
-      array = [true, false, false];
-      let Type = parameterized(Array, Boolean);
-      tree = analyze(Type, array);
-    });
+    let array = [true, false, false];
+    let { tree, value } = analyze(parameterized(Array, Boolean), array);
     it('has a node for each member of the array', function() {
       expect(tree.children.length).toBe(3);
       expect(tree.children[0]).toBeDefined();
@@ -131,10 +124,7 @@ describe('Structure', () => {
       expect(tree.data.stateAt(array)).toBe(array);
     });
     it('can invoke transitions on the subtypes', function() {
-      let invoke = jest.fn(() => ({
-        tree: analyze(Boolean, true),
-        value: true
-      }));
+      let invoke = jest.fn(() => (analyze(Boolean, true)));
       let transitions = tree.children[2].data.transitionsAt([true, false, false], tree, invoke);
 
       let { tree: nextTree, value: nextValue } = transitions.toggle();
@@ -142,10 +132,7 @@ describe('Structure', () => {
     });
 
     it('updates a tree to keep in sync with array transitions', function() {
-      let invoke = jest.fn(() => ({
-        tree: analyze(parameterized(Array, Boolean), [true, false]),
-        value: [true, false]
-      }));
+      let invoke = jest.fn(() => analyze(parameterized(Array, Boolean), [true, false]));
       let transitions = tree.data.transitionsAt([true, false, false], tree, invoke);
       let { tree: nextTree, value: nextValue } = transitions.pop();
       expect(nextValue).toEqual([true, false]);
@@ -156,11 +143,8 @@ describe('Structure', () => {
   });
 
   describe('An Unparameterized Array', function() {
-    let array;
-    beforeEach(function() {
-      array = [1, 2, 3];
-      tree = analyze(Array, array);
-    });
+    let array = [1, 2, 3];
+    let { tree, value } = analyze(Array, array);
     it('does not have child nodes for its children', function() {
       expect(tree.children.length).toBe(0);
     });
@@ -171,12 +155,8 @@ describe('Structure', () => {
   });
 
   describe('A Parameterized Object', function() {
-    let object;
-    beforeEach(function() {
-      object = {one: 1, two: 2};
-      let Type = parameterized(Object, Number);
-      tree = analyze(Type, object);
-    });
+    let object = {one: 1, two: 2};
+    let { tree, value } = analyze(parameterized(Object, Number), object);
     it('has a node for each entry in the object', function() {
       expect(tree.children.one).toBeDefined();
       expect(tree.children.two).toBeDefined();
@@ -186,10 +166,7 @@ describe('Structure', () => {
       expect(tree.data.stateAt(object)).toBe(object);
     });
     it('can invoke transitions on the subtypes', function() {
-      let invoke = jest.fn(() => ({
-        tree: analyze(Number, 2),
-        value: 2
-      }));
+      let invoke = jest.fn(() => analyze(Number, 2));
       let transitions = tree.children.one.data.transitionsAt(object, tree, invoke);
 
       let { tree: nextTree, value: nextValue } = transitions.increment();
@@ -197,10 +174,7 @@ describe('Structure', () => {
     });
 
     it('updates a tree to keep in sync with array transitions', function() {
-      let invoke = jest.fn(() => ({
-        tree: analyze(parameterized(Object, Number), {one: 1, two: 2, three: 3}),
-        value: {one: 1, two: 2, three: 3}
-      }));
+      let invoke = jest.fn(() => analyze(parameterized(Object, Number), {one: 1, two: 2, three: 3}));
       let transitions = tree.data.transitionsAt(object, tree, invoke);
       let { tree: nextTree, value: nextValue } = transitions.assign({three: 3});
       expect(nextValue).toEqual({one: 1, two: 2, three: 3});
@@ -212,5 +186,3 @@ describe('Structure', () => {
 
 
 });
-
-import logTree from '../src/utils/log-tree';

--- a/tests/type-shifting.test.js
+++ b/tests/type-shifting.test.js
@@ -416,7 +416,6 @@ describe('type-shifting from create to parameterized array', () => {
       expect(descriptor.get).toBeUndefined();
     });
   });
-
 });
 
 describe('type-shifting from create nodes in single operation', () => {

--- a/tests/type-shifting.test.js
+++ b/tests/type-shifting.test.js
@@ -450,7 +450,6 @@ describe('type-shifting from create to parameterized object', () => {
   class Parent {
     name = String;
   }
-
   class Person {
     parents = { Parent }
 
@@ -476,6 +475,7 @@ describe('type-shifting from create to parameterized object', () => {
   });
 
   it('has name with initial values', () => {
+    expect(person.state.parents.father).toBeInstanceOf(Parent);
     expect(person.state).toMatchObject({
       parents: {
         father: {
@@ -486,6 +486,19 @@ describe('type-shifting from create to parameterized object', () => {
         }
       }
     })
+  });
+
+  it('has valueOf', () => {
+    expect(person.valueOf()).toEqual({
+      parents: {
+        father: {
+          name: 'John Doe'
+        },
+        mother: {
+          name: 'Jane Doe'
+        }
+      }
+    });
   });
 });
 
@@ -531,7 +544,22 @@ describe('type-shifting from create nodes in single operation', () => {
         }
       }
     })
-  })
+  });
+
+  it('has valueOf', () => {
+    expect(root.valueOf()).toMatchObject({
+      name: 'Default for Root',
+      first: {
+        name: undefined,
+        second: {
+          name: 'Provided name for Second',
+          third: {
+            name: 'Default for Third'
+          }
+        }
+      }
+    })
+  });
 });
 
 describe('type-shifting with create in from none root node', () => {

--- a/tests/type-shifting.test.js
+++ b/tests/type-shifting.test.js
@@ -286,5 +286,45 @@ describe("type-shifting into a deeply composed microstate", () => {
       })
     });
   });
-
 });
+
+describe("type-shifting in a getter", () => {
+  class Node {
+    depth = Number;
+
+    get next() {
+      return create(Node, { depth: this.depth + 1 }).state;
+    }
+  }
+
+  let root = create(Node);
+
+  it('allows to create nodes', () => {
+    expect(root.state.depth).toBe(0);
+    expect(root.state.next.depth).toBe(1);
+    expect(root.state.next.next.depth).toBe(2);
+  });
+});
+
+describe.skip("type-shifting recursively with create", () => {
+  // this fails with: RangeError: Maximum call stack size exceeded
+  // I suspect this is because `create` is eager, it would be cool if
+  // we could make this lazy and thereby allow tree to be pulled on demand
+
+  class Node {
+    depth = Number;
+    node = Node;
+
+    static create({ depth = 0 } = {}) {
+      return create(Node, { depth, node: { depth: depth + 1 } });
+    }
+  }
+
+  let root = create(Node);
+
+  it('allows to create nodes', () => {
+    expect(root.state.depth).toBe(0);
+    expect(root.state.node.depth).toBe(1)
+  });
+});
+

--- a/tests/type-shifting.test.js
+++ b/tests/type-shifting.test.js
@@ -1,8 +1,7 @@
-import 'jest';
-import { create } from 'microstates';
+import "jest";
+import { create } from "microstates";
 
-describe('type-shifting', () => {
-
+describe("type-shifting", () => {
   class Shape {
     static create({ a, b, c } = {}) {
       if (a && b && c) {
@@ -42,15 +41,14 @@ describe('type-shifting', () => {
     shape = Shape;
   }
 
-  describe('create', function() {
-
-    it('can initialize to itself', () => {
+  describe("create", function() {
+    it("can initialize to itself", () => {
       let shape = create(Shape);
       expect(shape.state).toBeInstanceOf(Shape);
     });
 
-    it('initializes to first type', () => {
-      let triangle = Shape.create({a: 10, b: 20, c: 30 });
+    it("initializes to first type", () => {
+      let triangle = Shape.create({ a: 10, b: 20, c: 30 });
       expect(triangle.state).toBeInstanceOf(Triangle);
       expect(triangle.state).toMatchObject({
         a: 10,
@@ -59,25 +57,25 @@ describe('type-shifting', () => {
       });
     });
 
-    it('initializes to second type', () => {
-      let angle = Shape.create({a: 10, b: 20 });
+    it("initializes to second type", () => {
+      let angle = Shape.create({ a: 10, b: 20 });
       expect(angle.state).toBeInstanceOf(Angle);
       expect(angle.state).toMatchObject({
         a: 10,
-        b: 20,
+        b: 20
       });
     });
 
     it(`can be initialized from descendant's create`, function() {
-      let line = Line.create({ a: 10 });      
+      let line = Line.create({ a: 10 });
       expect(line.state).toBeInstanceOf(Line);
       expect(line.state).toMatchObject({
         a: 10
       });
     });
 
-    it('is used to initialize composed object', function() {     
-      let composed = create(Glass, { shape : {a: 10, b: 20, c: 30 }}); 
+    it("is used to initialize composed object", function() {
+      let composed = create(Glass, { shape: { a: 10, b: 20, c: 30 } });
       expect(composed.state.shape).toBeInstanceOf(Triangle);
       expect(composed.state).toMatchObject({
         shape: {
@@ -88,41 +86,42 @@ describe('type-shifting', () => {
       });
     });
 
-    it('supports being initialized in parameterized arrays', () => {
+    it("supports being initialized in parameterized arrays", () => {
       class Drawing {
-        shapes = [Shape]
+        shapes = [Shape];
       }
-      let drawing = create(Drawing, { shapes: [ { a: 10 }, { a: 20, b: 30 }, { a: 100, b: 200, c: 300 }]});
+      let drawing = create(Drawing, {
+        shapes: [{ a: 10 }, { a: 20, b: 30 }, { a: 100, b: 200, c: 300 }]
+      });
       expect(drawing.state.shapes[0]).toBeInstanceOf(Line);
       expect(drawing.state.shapes[1]).toBeInstanceOf(Angle);
-      expect(drawing.state.shapes[2]).toBeInstanceOf(Triangle);            
+      expect(drawing.state.shapes[2]).toBeInstanceOf(Triangle);
     });
 
-    describe('can type-shift into a parameterized type', () => {
+    describe("can type-shift into a parameterized type", () => {
       class Container {
         static create(content) {
           if (Array.isArray(content)) {
             return create([String], content);
           } else {
-            return create({String}, content);
+            return create({ String }, content);
           }
         }
       }
-      it('can initialize into a parameterized array', () => {
-        let array = Container.create(['a', 'b', 'c']);
-        expect(array.state).toMatchObject(['a', 'b', 'c']);
+      it("can initialize into a parameterized array", () => {
+        let array = Container.create(["a", "b", "c"]);
+        expect(array.state).toMatchObject(["a", "b", "c"]);
         expect(array[0].concat).toBeInstanceOf(Function);
       });
-      it('can initialize into a parameterized object', () => {
-        let object = Container.create({a: 'A', b: 'B', c: 'C'});
-        expect(object.state).toMatchObject({a: 'A', b: 'B', c: 'C'});
+      it("can initialize into a parameterized object", () => {
+        let object = Container.create({ a: "A", b: "B", c: "C" });
+        expect(object.state).toMatchObject({ a: "A", b: "B", c: "C" });
         expect(object.a.concat).toBeInstanceOf(Function);
       });
     });
-
   });
 
-  describe('transitions', function() {
+  describe("transitions", function() {
     let ms = create(Line);
     let line, corner, triangle;
     beforeEach(() => {
@@ -130,40 +129,40 @@ describe('type-shifting', () => {
       corner = line.add(20);
       triangle = corner.add(30);
     });
-    it('constructs a line', () => {
+    it("constructs a line", () => {
       expect(line.state).toBeInstanceOf(Line);
       expect(line.state).toMatchObject({
-        a: 10,
+        a: 10
       });
       expect(line.valueOf()).toEqual({ a: 10 });
     });
-    it('constructs a Corner', () => {
+    it("constructs a Corner", () => {
       expect(corner.state).toBeInstanceOf(Angle);
       expect(corner.state).toMatchObject({
         a: 10,
-        b: 20,
+        b: 20
       });
       expect(corner.valueOf()).toEqual({ a: 10, b: 20 });
     });
-    it('constructs a Triangle', () => {
+    it("constructs a Triangle", () => {
       expect(triangle.state).toBeInstanceOf(Triangle);
       expect(triangle.state).toMatchObject({
         a: 10,
         b: 20,
-        c: 30,
+        c: 30
       });
       expect(triangle.valueOf()).toEqual({ a: 10, b: 20, c: 30 });
     });
-    it('can be done down tree', () => {
-      let string = create(String, '100');
-      let cString = triangle.c.set(string)
-      expect(cString.state.c).toBe('100');
+    it("can be done down tree", () => {
+      let string = create(String, "100");
+      let cString = triangle.c.set(string);
+      expect(cString.state.c).toBe("100");
       expect(cString.c.concat).toBeDefined();
     });
   });
 });
 
-describe('type-shifting with constant values', () => {
+describe("type-shifting with constant values", () => {
   class Async {
     content = null;
     isLoaded = false;
@@ -185,15 +184,19 @@ describe('type-shifting with constant values', () => {
     isLoading = true;
 
     loaded(content) {
-      return create(class extends AsyncLoaded {
-        content = content;
-      });
+      return create(
+        class extends AsyncLoaded {
+          content = content;
+        }
+      );
     }
 
     error(msg) {
-      return create(class extends AsyncError {
-        error = msg;
-      });
+      return create(
+        class extends AsyncError {
+          error = msg;
+        }
+      );
     }
   }
 
@@ -202,35 +205,86 @@ describe('type-shifting with constant values', () => {
     isLoading = false;
     isError = false;
   }
-  describe('successful loading siquence', () => {
+  describe("successful loading siquence", () => {
     let async = create(Async);
-    it('can transition to loading', () => {
+    it("can transition to loading", () => {
       expect(async.loading().state).toMatchObject({
         content: null,
         isLoaded: false,
         isLoading: true,
-        isError: false,
+        isError: false
       });
     });
-    it('can transition from loading to loaded', () => {
-      expect(async.loading().loaded('GREAT SUCCESS').state).toMatchObject({
-        content: 'GREAT SUCCESS',
+    it("can transition from loading to loaded", () => {
+      expect(async.loading().loaded("GREAT SUCCESS").state).toMatchObject({
+        content: "GREAT SUCCESS",
         isLoaded: true,
         isLoading: false,
-        isError: false,
+        isError: false
       });
     });
   });
-  describe('error loading sequence', () => {
+  describe("error loading sequence", () => {
     let async = create(Async);
-    it('can transition from loading to error', () => {
-      expect(async.loading().error(':(').state).toMatchObject({
+    it("can transition from loading to error", () => {
+      expect(async.loading().error(":(").state).toMatchObject({
         content: null,
         isLoaded: true,
         isError: true,
         isLoading: false,
-        error: ':(',
+        error: ":("
       });
     });
   });
+});
+
+describe("type-shifting into a deeply composed microstate", () => {
+  class Node {
+    name = String;
+    node = Node;
+  }
+
+  let root = create(Node);
+
+  describe('shifting the root node', () => {
+
+    let shiftedRoot = root.set(
+      create(Node, { name: "n1", node: { name: "n2", node: { name: "n3" } } })
+    );
+
+    it("preserves type shifting value", () => {
+      expect(
+        shiftedRoot.state
+      ).toMatchObject({
+        name: 'n1',
+        node: { name: 'n2', node: { name: "n3" }}
+      });
+    });
+
+    it('preserves valueOf', () => {
+      expect(shiftedRoot.valueOf()).toEqual({
+        name: 'n1',
+        node: { name: 'n2', node: { name: "n3" }}
+      })
+    });
+  });
+
+  describe('shifting deeply composted state with new value', () => {
+    let shiftedDeeply = root.node.node.node.set({ name: "soooo deep", node: { name: 'one more' }});
+
+    it("preserves type shifting value", () => {
+      expect(
+        shiftedDeeply.state
+      ).toMatchObject({
+        node: { node: { node: { name: 'soooo deep', node: { name: 'one more' }}}}
+      });
+    });
+
+    it('preserves valueOf', () => {
+      expect(shiftedDeeply.valueOf()).toEqual({
+        node: { node: { node: { name: 'soooo deep', node: { name: 'one more' }}}}
+      })
+    });
+  });
+
 });

--- a/tests/type-shifting.test.js
+++ b/tests/type-shifting.test.js
@@ -348,12 +348,14 @@ describe('type-shifting from create to parameterized array', () => {
   }
 
   it('privides data to parameterized array', () => {
-    expect(create(Group).state).toMatchObject({
+    let { state } = create(Group);
+    expect(state).toMatchObject({
       members: [
         { name: 'Taras' },
         { name: 'Charles' },
         { name: 'Siva' }
       ]
     });
+    expect(state.members[0].name).toBe("Taras");
   });
 });

--- a/tests/type-shifting.test.js
+++ b/tests/type-shifting.test.js
@@ -347,15 +347,37 @@ describe('type-shifting from create to parameterized array', () => {
     }
   }
 
+  let group = create(Group);
+
   it('privides data to parameterized array', () => {
-    let { state } = create(Group);
-    expect(state).toMatchObject({
+    expect(group.state).toMatchObject({
       members: [
         { name: 'Taras' },
         { name: 'Charles' },
         { name: 'Siva' }
       ]
     });
-    expect(state.members[0].name).toBe("Taras");
+    expect(group.state.members[0]).toBeInstanceOf(Person);
+  });
+
+  it('has initialized valueOf', () => {
+    expect(group.valueOf()).toEqual({
+      members: [
+        { name: 'Taras' },
+        { name: 'Charles' },
+        { name: 'Siva' }
+      ]
+    })
+  });
+
+  it('can transition shifted value', () => {
+    let acclaimed = group.members[1].name.set('!!Charles!!');
+    expect(acclaimed.state).toMatchObject({
+      members: [
+        { name: 'Taras' },
+        { name: '!!Charles!!' },
+        { name: 'Siva' }
+      ]
+    })
   });
 });

--- a/tests/type-shifting.test.js
+++ b/tests/type-shifting.test.js
@@ -360,24 +360,28 @@ describe('type-shifting from create to parameterized array', () => {
     expect(group.state.members[0]).toBeInstanceOf(Person);
   });
 
-  it('has initialized valueOf', () => {
-    expect(group.valueOf()).toEqual({
-      members: [
-        { name: 'Taras' },
-        { name: 'Charles' },
-        { name: 'Siva' }
-      ]
-    })
+  describe('transitioning shifted value', () => {
+    let acclaimed = group.members[1].name.set('!!Charles!!');
+
+    it('has the transitioned state', () => {
+      expect(acclaimed.state).toMatchObject({
+        members: [
+          { name: 'Taras' },
+          { name: '!!Charles!!' },
+          { name: 'Siva' }
+        ]
+      })
+    });
+
+    it('carries the value of', () => {
+      expect(acclaimed.valueOf()).toEqual({
+        members: [
+          { name: 'Taras' },
+          { name: '!!Charles!!' },
+          { name: 'Siva' }
+        ]
+      });
+    });
   });
 
-  it('can transition shifted value', () => {
-    let acclaimed = group.members[1].name.set('!!Charles!!');
-    expect(acclaimed.state).toMatchObject({
-      members: [
-        { name: 'Taras' },
-        { name: '!!Charles!!' },
-        { name: 'Siva' }
-      ]
-    })
-  });
 });

--- a/tests/type-shifting.test.js
+++ b/tests/type-shifting.test.js
@@ -348,8 +348,30 @@ describe('type-shifting from create to parameterized array', () => {
   }
 
   let group = create(Group);
+  let value = group.valueOf();
 
-  it('privides data to parameterized array', () => {
+  it('initializes to value', () => {
+    expect(value).toMatchObject({
+      members: [
+        { name: 'Taras' },
+        { name: 'Charles' },
+        { name: 'Siva' }
+      ]
+    });
+  });
+
+  it('has a POJO as value', () => {
+    let descriptor = Object.getOwnPropertyDescriptor(value, 'members');
+    expect(descriptor).toHaveProperty('value', [
+      { name: 'Taras' },
+      { name: 'Charles' },
+      { name: 'Siva' }
+    ]);
+    expect(descriptor.get).toBeUndefined();
+  });
+
+  it('provides data to parameterized array', () => {
+    expect(group.state.members).toHaveLength(3);
     expect(group.state).toMatchObject({
       members: [
         { name: 'Taras' },
@@ -362,6 +384,7 @@ describe('type-shifting from create to parameterized array', () => {
 
   describe('transitioning shifted value', () => {
     let acclaimed = group.members[1].name.set('!!Charles!!');
+    let value = acclaimed.valueOf();
 
     it('has the transitioned state', () => {
       expect(acclaimed.state).toMatchObject({
@@ -374,13 +397,23 @@ describe('type-shifting from create to parameterized array', () => {
     });
 
     it('carries the value of', () => {
-      expect(acclaimed.valueOf()).toEqual({
+      expect(value).toEqual({
         members: [
           { name: 'Taras' },
           { name: '!!Charles!!' },
           { name: 'Siva' }
         ]
       });
+    });
+
+    it('has a POJO as value', () => {
+      let descriptor = Object.getOwnPropertyDescriptor(value, 'members');
+      expect(descriptor).toHaveProperty('value', [
+        { name: 'Taras' },
+        { name: '!!Charles!!' },
+        { name: 'Siva' }
+      ]);
+      expect(descriptor.get).toBeUndefined();
     });
   });
 

--- a/tests/type-shifting.test.js
+++ b/tests/type-shifting.test.js
@@ -418,3 +418,45 @@ describe('type-shifting from create to parameterized array', () => {
   });
 
 });
+
+describe('type-shifting from create nodes in single operation', () => {
+  class Root {
+    static create(params) {
+      if (!params) {
+        return create(Root, { name: 'Default for Root', first: { second: { name: 'Provided name for Second' } } })
+      }
+    }
+    name = String;
+    first = class First {
+      name = String;
+      second = class Second {
+        name = String;
+        third = class Third {
+          name = String;
+          static create(params) {
+            if (!params) {
+              return create(Third, { name: 'Default for Third' });
+            }
+          }
+        }
+      }
+    }
+  }
+
+  let root = create(Root);
+
+  it('has state for root', () => {
+    expect(root.state).toMatchObject({
+      name: 'Default for Root',
+      first: {
+        name: '',
+        second: {
+          name: 'Provided name for Second',
+          third: {
+            name: 'Default for Third'
+          }
+        }
+      }
+    })
+  })
+});

--- a/tests/type-shifting.test.js
+++ b/tests/type-shifting.test.js
@@ -328,3 +328,32 @@ describe.skip("type-shifting recursively with create", () => {
   });
 });
 
+describe('type-shifting from create to parameterized array', () => {
+  class Person {
+    name = String;
+  }
+
+  class Group {
+    members = [Person]
+
+    static create({ members } = {}) {
+      if (!members) {
+        return create(Group, { members: [
+          { name: 'Taras' },
+          { name: 'Charles' },
+          { name: 'Siva' }
+        ]});
+      }
+    }
+  }
+
+  it('privides data to parameterized array', () => {
+    expect(create(Group).state).toMatchObject({
+      members: [
+        { name: 'Taras' },
+        { name: 'Charles' },
+        { name: 'Siva' }
+      ]
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses an issue discovered when attempting to use `static create` method to initialize a parameterized array. The `static create` method was added to allow developers to control how a type is created. 

Expected: It should allow the developer to change the initialized type and value. The value of the microstate that is created in `static create` should be used for the `state` and `valueOf` the create microstate.

```js
class MatureStudent {
  canDrive = Boolean;
}

class Student {
  static create(attrs) {
    if (attrs > 21) {
       return create(MatureStudent, { ...attrs, canDrive: true });
    }
  }
}
```

In this example, I would expect `create(Student, { age: 40 }).state.canDrive === true`.

Actual: the value that was boxed in the microstate that was returned by `static create` was not being considered when create state of children. As a result, the composed states always their default state rather than the provided value.

## In this PR

This PR fixes this behavior by ensuring that value that's boxed in the returned microstate is 
1. applied to all of the grafted children
2. is available when building state for parameterized arrays and objects
3. is included in the valueOf on next transition

## Changes

1. `analyze` now returns `tree & value`.
2. when `static create` is used, the returned value is merged into valueOf using collapse value

## Notable discoveries.

1. `static create` is eager which prevents us from being able to make recursive `static create`
2. (I think) `valueOf` should become lazy and should only be materialized when `ms.valueOf()` is called
3. Location typeclass should probably include `valueOf`

# TODO
- [x] recursively shifting children
- [x] shifting values into nodes of parameterized data types 
- [x] collapse value to allow transitioning shifted parameterized data types  