### PR TITLE
Fix Array transitions

### DIFF
--- a/src/structure.js
+++ b/src/structure.js
@@ -2,7 +2,7 @@ import $ from './utils/chain';
 import { type, map, append, pure } from 'funcadelic';
 import { flatMap } from './monad';
 import { view, set, lensTree, lensPath } from './lens';
-import Tree from './utils/tree';
+import Tree, { graft, prune } from './utils/tree';
 import transitionsFor from './utils/transitions-for';
 import { reveal } from './utils/secret';
 import types, { params, any, toType } from './types';
@@ -26,7 +26,7 @@ function analyzeType(value) {
     let InitialType = desugar(node.Type);
     let valueAt = node.valueAt(value);
     let Type = toType(InitialType);
-    
+
     let instance = Type.hasOwnProperty('create') ? Type.create(valueAt) : undefined;
 
     if (instance instanceof Microstate) {
@@ -105,40 +105,6 @@ function truncate(fn, tree) {
       return subtree;
     }
   }, tree);
-}
-
-/**
- * Turn any structure tree into a root tree.
- *
- * Every node in a tree knows its path. This path is what identifies
- * its context in the containing tree.
- *
- * This lets you take any tree, sitting at any context and make it
- * "context free". I.e. converts it into a root.
- *
- * @param {Tree} tree - the tree to isolate
- * @returns {Tree} - a tree just like `tree`, but now a root.
- */
-function prune(tree) {
-  let prefix = tree.data.path;
-  return map(node => append(node, { path: node.path.slice(prefix.length)}), tree);
-}
-
-/**
- * Change the path of a tree.
- *
- * This lets you take any tree, sitting at any context and prefix the context with
- * additional path.
- *
- * @param {*} tree
- * @param {*} path
- */
-function graft(path, tree) {
-  if (path.length === 0) {
-    return tree;
-  } else {
-    return map(node => append(node, { path: [...path, ...node.path]}), tree);
-  }
 }
 
 class Node {

--- a/src/utils/tree.js
+++ b/src/utils/tree.js
@@ -32,3 +32,37 @@ export default class Tree {
     }
   }
 }
+
+/**
+ * Turn any structure tree into a root tree.
+ *
+ * Every node in a tree knows its path. This path is what identifies
+ * its context in the containing tree.
+ *
+ * This lets you take any tree, sitting at any context and make it
+ * "context free". I.e. converts it into a root.
+ *
+ * @param {Tree} tree - the tree to isolate
+ * @returns {Tree} - a tree just like `tree`, but now a root.
+ */
+export function prune(tree) {
+  let prefix = tree.data.path;
+  return map(node => append(node, { path: node.path.slice(prefix.length)}), tree);
+}
+
+/**
+ * Change the path of a tree.
+ *
+ * This lets you take any tree, sitting at any context and prefix the context with
+ * additional path.
+ *
+ * @param {*} tree
+ * @param {*} path
+ */
+export function graft(path, tree) {
+  if (path.length === 0) {
+    return tree;
+  } else {
+    return map(node => append(node, { path: [...path, ...node.path]}), tree);
+  }
+}

--- a/tests/types/array.test.js
+++ b/tests/types/array.test.js
@@ -3,37 +3,87 @@ import 'jest';
 import ArrayType from '../../src/types/array';
 import { create } from 'microstates';
 
-let array = ['a', 'b', 'c'];
-let ms = create(Array, array);
+describe('ArrayType', function() {
+  let array = ['a', 'b', 'c'];
 
-it('constructor returns an array when receives another value', () => {
-  expect(new ArrayType()).toEqual([]);
-  expect(new ArrayType('foo')).toEqual(['foo']);
-  expect(new ArrayType(false)).toEqual([false]);
-});
+  describe('when unparameterized', function() {
+    let ms = create(Array, array);
 
-it('constructor returns the array when one is passed', () => {
-  expect(new ArrayType(array)).toBe(array);
-});
+    it('constructor returns an array when receives another value', () => {
+      expect(new ArrayType()).toEqual([]);
+      expect(new ArrayType('foo')).toEqual(['foo']);
+      expect(new ArrayType(false)).toEqual([false]);
+    });
 
-it('filter removes items', () => {
-  expect(ms.filter(v => v !== 'a').valueOf()).toEqual(['b', 'c']);
-});
+    it('constructor returns the array when one is passed', () => {
+      expect(new ArrayType(array)).toBe(array);
+    });
 
-it('map applies to every item', () => {
-  expect(ms.map(v => v.toUpperCase()).valueOf()).toEqual(['A', 'B', 'C']);
-});
+    it('pushes items', function() {
+      let next = ms.push('d').push('e');
+      expect(next.valueOf()).toEqual(['a', 'b', 'c', 'd', 'e']);
+      expect(next.state).toEqual(['a', 'b', 'c', 'd', 'e']);
+    });
 
-it('replace replaces first element', () => {
-  expect(ms.replace('a', 'd').valueOf()).toEqual(['d', 'b', 'c']);
-});
+    it('filter removes items', () => {
+      expect(ms.filter(v => v !== 'a').valueOf()).toEqual(['b', 'c']);
+    });
 
-it('replace does not throw when replacing non-existing item', () => {
-  expect(() => {
-    ms.replace('e', 'd');
-  }).not.toThrow();
-});
+    it('map applies to every item', () => {
+      expect(ms.map(v => v.toUpperCase()).valueOf()).toEqual(['A', 'B', 'C']);
+    });
 
-it('replace returns same array when value not found', () => {
-  expect(ms.replace('e', 'd').valueOf()).toBe(array);
+    it('replace replaces first element', () => {
+      expect(ms.replace('a', 'd').valueOf()).toEqual(['d', 'b', 'c']);
+    });
+
+    it('replace does nont throw when replacing non-existing item', () => {
+      expect(() => {
+        ms.replace('e', 'd');
+      }).not.toThrow();
+    });
+
+    it('replace returns same array when value not found', () => {
+      expect(ms.replace('e', 'd').valueOf()).toBe(array);
+    });
+  });
+
+
+  describe('when parameterized', function() {
+    class Thing {}
+    let ms = create([Thing], array);
+
+    it('has instances of the state for each value in the array', function() {
+      expect(ms.state.length).toBe(3);
+      expect(ms.state[0]).toBeInstanceOf(Thing);
+      expect(ms.state[1]).toBeInstanceOf(Thing);
+      expect(ms.state[2]).toBeInstanceOf(Thing);
+    });
+
+    it('can push values', function() {
+      let pushed = ms.push('d');
+      expect(pushed.valueOf()).toEqual(['a', 'b', 'c', 'd']);
+      expect(pushed.state.length).toEqual(4);
+      expect(pushed.state[3]).toBeInstanceOf(Thing);
+    });
+    it('can pop values', function() {
+      let popped = ms.pop();
+      expect(popped.valueOf()).toEqual(['a', 'b']);
+      expect(popped.state.length).toEqual(2);
+      expect(popped.state[1]).toBeInstanceOf(Thing);
+    });
+    it('can unshift values', function () {
+      let unshifted = ms.unshift('d');
+      expect(unshifted.valueOf()).toEqual(['d', 'a', 'b', 'c']);
+      expect(unshifted.state.length).toEqual(4);
+      expect(unshifted.state[0]).toBeInstanceOf(Thing);
+    });
+    it('can shift values', function () {
+      let shifted = ms.shift();
+      expect(shifted.valueOf()).toEqual(['b', 'c']);
+      expect(shifted.state.length).toEqual(2);
+      expect(shifted.state[0]).toBeInstanceOf(Thing);
+      expect(shifted.state[1]).toBeInstanceOf(Thing);
+    });
+  });
 });


### PR DESCRIPTION
With the advent of parameterized types, the tree can extend _below_ the Array type, so it isn't enough just to work with the state or the value. We need to keep the tree in sync.

This implements a `splice` transition on the `ArrayType` which actually modifies the microstate tree to keep in sync with the value, and then `push`, `pop`, and `filter`, are implemented in terms of `splice`. Any nodes that can be shared are shared.

This is clearly not optimal, but we need to see what tree modification patterns look like for Object and others before abstracting.

### Notes

- In order to make module compilation work, I had to move `graft` and `prune` into the tree file.
- Because of cyclic dependencies, I had to get `create` and `Microstate` from the constructor. Again, this isn't ideal, but when we can find out what the right abstraction is, then the individual types should not need to know about Microstate at all.