### PR TITLE
Stabilize state property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3850,9 +3850,9 @@
       }
     },
     "funcadelic": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/funcadelic/-/funcadelic-0.3.5.tgz",
-      "integrity": "sha1-Pmzc2VXBV9Gh2ye6xEi3NLkLZXw=",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/funcadelic/-/funcadelic-0.3.6.tgz",
+      "integrity": "sha1-n2rv8R/uWRV+cMHKKfPMN/kwSMs=",
       "requires": {
         "babel-plugin-external-helpers": "6.22.0",
         "lodash.curry": "4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1134,6 +1134,14 @@
         "babel-runtime": "6.26.0"
       }
     },
+    "babel-plugin-external-helpers": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz",
+      "integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz",
@@ -1601,7 +1609,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
       "requires": {
         "core-js": "2.5.3",
         "regenerator-runtime": "0.11.1"
@@ -2251,8 +2258,7 @@
     "core-js": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
-      "dev": true
+      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3844,10 +3850,11 @@
       }
     },
     "funcadelic": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/funcadelic/-/funcadelic-0.3.3.tgz",
-      "integrity": "sha1-mTKKMqzMh7vhv8bgpIYfRsrxDPk=",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/funcadelic/-/funcadelic-0.3.5.tgz",
+      "integrity": "sha1-Pmzc2VXBV9Gh2ye6xEi3NLkLZXw=",
       "requires": {
+        "babel-plugin-external-helpers": "6.22.0",
         "lodash.curry": "4.1.1",
         "object.getownpropertydescriptors": "2.0.3"
       }
@@ -6319,8 +6326,7 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regenerator-transform": {
       "version": "0.12.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "start": "npm test -- --watch"
   },
   "dependencies": {
-    "funcadelic": "^0.3.2",
+    "funcadelic": "0.3.5",
     "object.getownpropertydescriptors": "2.0.3",
     "ramda": "^0.25.0",
     "symbol-observable": "1.2.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "start": "npm test -- --watch"
   },
   "dependencies": {
-    "funcadelic": "0.3.5",
+    "funcadelic": "0.3.6",
     "object.getownpropertydescriptors": "2.0.3",
     "ramda": "^0.25.0",
     "symbol-observable": "1.2.0"

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import Microstate from './microstate';
 
 export default Microstate;
 export const { create } = Microstate;
+export { reveal } from './utils/secret';
 
 export { default as Microstate } from './microstate';
 export { default as Tree } from './utils/tree';

--- a/src/microstate.js
+++ b/src/microstate.js
@@ -1,12 +1,18 @@
-import { map } from "funcadelic";
+import { map, append } from "funcadelic";
 import analyze, { collapseState } from "./structure";
 import { keep, reveal } from "./utils/secret";
 import SymbolObservable from "symbol-observable";
 
 export default class Microstate {
   constructor(tree, value) {
+
     keep(this, { tree, value });
-    return map(transition => transition, this);
+
+    return append(map(transition => transition, this), {
+      get state() {
+        return collapseState(tree, value);
+      }
+    });
   }
 
   /**
@@ -21,15 +27,6 @@ export default class Microstate {
     value = value != null ? value.valueOf() : value;
     let tree = analyze(Type, value);
     return new Microstate(tree, value);
-  }
-
-  /**
-   * Evaluates to state for this microstate.
-   */
-  get state() {
-    let { tree, value } = reveal(this);
-
-    return collapseState(tree, value);
   }
 
   /**

--- a/tests/state.test.js
+++ b/tests/state.test.js
@@ -4,6 +4,7 @@ import { parameterized } from '../src/types/parameters';
 import analyze from '../src/structure';
 import { map } from 'funcadelic';
 import { collapse } from '../src/typeclasses/collapse';
+import { create } from 'microstates';
 
 function node(Type, value) {
   return analyze(Type, value).data;
@@ -42,6 +43,22 @@ describe('State', () => {
       expect(state.firstName).toEqual('Charles');
       expect(state.lastName).toEqual('Lowell');
       expect(state.fullName).toEqual('Charles Lowell');
+    });
+  });
+
+  describe('stability', () => {
+    describe('reading state root', () => {
+      class Node {
+        node = Node
+      }
+      let ms = create(Node);
+      it('returns the same root state', () => {
+        expect(ms.state).toBe(ms.state);
+      });
+      it('returns the same node when composed state is read twice', () => {
+        expect(ms.state.node).toBe(ms.state.node);
+        expect(ms.state.node.node).toBe(ms.state.node.node);
+      });
     });
   });
 });


### PR DESCRIPTION
This PR is the beginning of stabilizing microstates. Stability is another way of saying `referential integrity`. True stability will take time to achieve, but this PR is the beginning of the journey towards stable microstates.

This PR makes the state getter stable. Stable getters is a functionality that's provided by `funcadelic@0.3.6` which caches the value returned by a getter for a specific instance.  By caching the state property, we ensure that when state is read it always evaluates to the same value.

In other words,

```js
class Modal {
  isOpen = Boolean;
  content = String;
}

let modal = create(Modal);

modal.state === modal.state;
// => true
```

**Note**: this is accomplished without mutating the microstate.