### PR TITLE
Concentrate Lens logic in the lens module.

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,6 @@ const globals = {
   "ramda/src/lens": "R.lens",
   "ramda/src/view": "R.view",
   "ramda/src/set": "R.set",
-  "ramda/src/lensPath": "R.lensPath",
   "ramda/src/indexOf": "R.indexOf",
   "ramda/src/compose": "R.compose",
   "object.getownpropertydescriptors": "Object.getownpropertydescriptors",

--- a/src/lens.js
+++ b/src/lens.js
@@ -7,8 +7,11 @@ export { default as compose } from 'ramda/src/compose';
 
 import lens from 'ramda/src/lens';
 import view from 'ramda/src/view';
+import lset from 'ramda/src/set';
+import lensPath from 'ramda/src/lensPath';
 import Tree from './utils/tree';
-import { map, foldl } from 'funcadelic';
+import { append, map, foldl } from 'funcadelic';
+
 
 export function lensTreeValue(path = []) {
   function get(tree) {
@@ -21,7 +24,11 @@ export function lensTreeValue(path = []) {
     } else {
       return new Tree({
         data: () => {
-          return tree.data.replaceValue(current, subtree.data.value);
+          return append(tree.data, {
+            get value() {
+              return lset(lensPath(current), subtree.data.value, tree.data.value);
+            }
+          });
         },
         children: () =>
           map((child, childName) => {

--- a/src/structure.js
+++ b/src/structure.js
@@ -1,6 +1,6 @@
 import $ from './utils/chain';
 import { type, map, append, pure, flatMap } from 'funcadelic';
-import { view, set, over, lensPath, lensTreeValue } from './lens';
+import { over, lensTreeValue } from './lens';
 import Tree, { prune, graft } from './utils/tree';
 import transitionsFor from './utils/transitions-for';
 import { reveal } from './utils/secret';
@@ -46,9 +46,15 @@ class Node {
     this.InitialType = InitialType;
     this.path = path;
 
-    Object.defineProperty(this, 'value', {
-      enumerable: true,
-      get: thunk(() => view(lensPath(path.slice(-1)), root))
+    return append(this, {
+      get value() {
+        if (path.length === 0) {
+          return root;
+        } else {
+          let key = path.slice(-1)[0];
+          return root != null ? root[key] : root;
+        }
+      }
     });
   }
 
@@ -86,14 +92,5 @@ class Node {
 
   createChild(Type, name, rootValue) {
     return new Node({path: append(this.path, name), Type, root: rootValue });
-  }
-
-  replaceValue(key, childValue) {
-    let { Type, value } = this;
-    return append(this, {
-      get value() {
-        return set(lensPath(key), childValue, value);
-      }
-    });
   }
 }

--- a/src/types/array.js
+++ b/src/types/array.js
@@ -38,7 +38,7 @@ class ArrayType {
 
     return this.set(result);
   }
-  
+
   map(callback) {
     return this.set(Array.prototype.map.call(this.state, callback));
   }
@@ -49,14 +49,14 @@ class ArrayType {
     let tree = reveal(this);
     let value = (this.valueOf() || []).slice();
     value.splice(startIndex, length, ...values);
-    
+
     let { T } = params(tree.data.Type);
     if (T === any) {
       return this.set(value);
     }
-    
+
     let unchanged = tree.children.slice(0, startIndex);
-    
+
     let added = $(values)
         .map(value => create(T, value))
         .map(reveal)
@@ -79,26 +79,6 @@ class ArrayType {
     });
 
     return new Microstate(structure);
-  }
-  /**
-   * Return a new array with first occurance of found item
-   * replaced with the replacement. It is very optimistic and
-   * will not throw even when item is not found.
-   *
-   * ```js
-   * let ms = microstate(MS.Array, ['a', 'b', 'c']);
-   * // => [ d, b, c ]
-   * ```
-   * @param {any} item
-   * @param {any} replacement
-   */
-  replace(item, replacement) {
-    let index = indexOf(item, this.state);
-    if (index === -1) {
-      return this.set(this.state);
-    } else {
-      return this.set(set(lensPath([index]), replacement, this.state));
-    }
   }
 }
 

--- a/tests/types/array.test.js
+++ b/tests/types/array.test.js
@@ -32,20 +32,6 @@ describe('ArrayType', function() {
     it('map applies to every item', () => {
       expect(ms.map(v => v.toUpperCase()).valueOf()).toEqual(['A', 'B', 'C']);
     });
-
-    it('replace replaces first element', () => {
-      expect(ms.replace('a', 'd').valueOf()).toEqual(['d', 'b', 'c']);
-    });
-
-    it('replace does nont throw when replacing non-existing item', () => {
-      expect(() => {
-        ms.replace('e', 'd');
-      }).not.toThrow();
-    });
-
-    it('replace returns same array when value not found', () => {
-      expect(ms.replace('e', 'd').valueOf()).toBe(array);
-    });
   });
 
 


### PR DESCRIPTION
We want to get to a point where we merge nodes and trees so that we can calculate complete things like states from directly within the node without any further context.

As a first step towards making that work, this removes lensing logic where it isn't needed, and moves ones that are still needed into the lensing module. That way, when we do need to make changes to the way the tree is changed, it can happen all in a single place.