### PR TITLE
upgrade funcadelic.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint src"
   },
   "dependencies": {
-    "funcadelic": "0.4.0",
+    "funcadelic": "0.4.1",
     "object.getownpropertydescriptors": "2.0.3",
     "ramda": "^0.25.0",
     "symbol-observable": "1.2.0"


### PR DESCRIPTION
## Purpose

It turns out that v0.4.0 of funcadelic was incompatible with ReactNative https://github.com/cowboyd/funcadelic.js/pull/40 In order to make microstates compatible with React Native, we need to pull in a funcadelic version that is.

## Approach

Straight up upgrade from 0.4.0 -> 0.4.1