### PR TITLE
Add the ability to include Microstates in Microstates.from

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -83,7 +83,19 @@ export class Microstate {
   }
 
   static from(value) {
-    return Tree.from(value).microstate;
+    return flatMap(tree => tree.assign({
+      meta: {
+        children() {
+          return map((child, key) => {
+            if (child.value instanceof Microstate) {
+              return reveal(child.value).graft([key]);
+            } else {
+              return child;
+            }
+          }, tree.children);
+        }
+      }
+    }), Tree.from(value)).microstate
   }
 
   static create(Type, value) {
@@ -135,7 +147,7 @@ export default class Tree {
   static from(value, T = types.Any) {
     if (value && value instanceof Microstate) {
       return reveal(value);
-    } else if (value) {
+    } else if (value != null) {
       return new Tree({ value, Type: T === types.Any ? value.constructor : T});
     } else {
       return new Tree({ value });

--- a/tests/tree.test.js
+++ b/tests/tree.test.js
@@ -10,6 +10,13 @@ import { resolveType, stabilizeClass, transitionsClass } from '../src/tree';
 const { assign } = Object;
 
 describe('from', () => {
+
+  it('detects falsy primitive values as their type', () => {
+    expect(Tree.from('')).toHaveProperty('Type', types.String);
+    expect(Tree.from(0)).toHaveProperty('Type', types.Number);    
+    expect(Tree.from(false)).toHaveProperty('Type', types.Boolean);
+  });
+
   it('converts undefined to any', () => {
     let tree = Tree.from();
     let microstate = tree.microstate;
@@ -70,6 +77,27 @@ describe('from', () => {
     let microstate = Microstate.from(42);
     expect(microstate).toHaveProperty('increment');
     expect(microstate.valueOf()).toBe(42);
+  });
+
+  it('allows composed value to be a microstate', () => {
+    let microstate = Microstate.from({
+      fortyTwo: Microstate.from(42),
+      name: Microstate.from('Charles')
+    });
+    expect(microstate.fortyTwo).toHaveProperty('increment');
+    expect(microstate.name).toHaveProperty('concat');
+    expect(microstate.valueOf()).toEqual({ name: 'Charles', fortyTwo: 42 });
+
+    expect(microstate.fortyTwo.increment().valueOf()).toEqual({ fortyTwo: 43, name: 'Charles' })
+  });
+
+  it('allows deeply composed value to be a microstate', () => {
+    let microstate = Microstate.from([
+      [Microstate.from(42)]
+    ]);
+    expect(microstate[0][0]).toHaveProperty('increment');
+    expect(microstate.valueOf()).toEqual([[42]]);
+    expect(microstate[0][0].increment().valueOf()).toEqual([[43]]);
   });
 });
 


### PR DESCRIPTION
Currently, it's only possible to use `Microstates.from` on objects, arrays and primitive values. This PR adds the ability to include Microstates. 

For example, you can do the following,

```js
let counter = Microstates.create(Number);
let modal = Microstates.create(Modal, { isOpen: true });
let authentication = Microstates.create(Authentication, { token: false });

let composed = Microstates.from({ counter, modal, authentication });
```

The created Microstates will be equivalent to doing,

```js
class App {
  counter = Number;
  modal = Modal;
  authentication = Authentication;
}

let app = Microstates.create(App, { modal: { isOpen: true }, authentication: { token: false } });
```

This will make it easy to compose multiple microstates in React.

This is a first step in process of implementing #114 