### PR TITLE
Added @@observable to add compatibility with RxJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "rollup": "^0.53.0",
     "rollup-plugin-babel": "^4.0.0-beta.0",
     "rollup-plugin-filesize": "1.5.0",
-    "rxjs": "6.0.0",
+    "rxjs": "6.1.0",
     "standard-version": "^4.2.0"
   },
   "jest": {

--- a/src/tree.js
+++ b/src/tree.js
@@ -104,7 +104,8 @@ export class Microstate {
     return reveal(this).state;
   }
 
-  [SymbolObservable]() {
+  [SymbolObservable]() { return this['@@observable'](); }
+  ['@@observable']() {
     let microstate = this;
     return {
       subscribe(observer) {

--- a/tests/observable-test.js
+++ b/tests/observable-test.js
@@ -1,7 +1,7 @@
 import "jest";
 import { create } from "microstates";
 import SymbolObservable from 'symbol-observable';
-import { Observable, from } from 'rxjs';
+import { from } from 'rxjs';
 
 describe('rxjs interop', function() {
   let ms, observable, observer, last;


### PR DESCRIPTION
This PR makes it easier to use Microstates with RxJS by using `@@observable` along side `Symbol.Observable`. This is necessary because RxJS no longer polyfills `Symbol.Observable` 

**See**: https://github.com/ReactiveX/rxjs/pull/3387

**Context**:
<img width="389" alt="screen shot 2018-05-16 at 10 30 22 pm" src="https://user-images.githubusercontent.com/74687/40153712-0361935c-5959-11e8-8a6c-a5444600b697.png">
