### PR TITLE
Updated dependencies that exclude object.getownpropertydescriptors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 
 node_js:
+  - "10"
   - "9"
   - "8"
   - "7"

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   },
   "dependencies": {
     "funcadelic": "0.4.1",
-    "get-prototype-descriptors": "0.5.0",
-    "memoize-getters": "1.0.0",
+    "get-prototype-descriptors": "0.6.0",
+    "memoize-getters": "1.1.0",
     "ramda": "^0.25.0",
     "symbol-observable": "1.2.0"
   },
@@ -54,6 +54,7 @@
     "jest-runner-eslint": "0.4.0",
     "jsonfile": "^4.0.0",
     "lint-staged": "6.0.0",
+    "object.getownpropertydescriptors": "2.0.3",
     "prettier": "^1.10.2",
     "pretty-error": "2.1.1",
     "pretty-format": "22.1.0",
@@ -64,7 +65,8 @@
     "standard-version": "^4.2.0"
   },
   "jest": {
-    "globalSetup": "./build.js",
+    "setupFiles": ["./scripts/shims.js"],
+    "globalSetup": "./scripts/build.js",
     "collectCoverageFrom": [
       "dist/microstates.umd.js"
     ],

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,5 +1,5 @@
 const rollup = require("rollup");
-const config = require("./rollup.config");
+const config = require("../rollup.config");
 const PrettyError = require('pretty-error');
 const pe = new PrettyError();
 pe.skipNodeFiles();

--- a/scripts/shims.js
+++ b/scripts/shims.js
@@ -1,0 +1,3 @@
+import getOwnPropertyDescriptors from 'object.getownpropertydescriptors';
+
+global.Object.getOwnPropertyDescriptors = global.Object.getOwnPropertyDescriptors || getOwnPropertyDescriptors;


### PR DESCRIPTION
I removed `object.getownpropertydescriptors` from dependencies of these 2 projects to reduce bundle size by 5.7kB for each. I'm adding the polyfill to this project for Node 6 compatibility. 

* [get-prototype-descriptors](https://github.com/taras/get-prototype-descriptors/pull/1)
* [memoize-getters](https://github.com/taras/memoize-getters/pull/2)