### PR TITLE
Allow putting and assigning microstates to objects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import './typeclasses';
 import { Microstate } from './tree';
 
 export default Microstate;
-export const { create } = Microstate;
+export const { create, from } = Microstate;
 export { reveal } from './utils/secret';
 export { default as types } from './types';
 

--- a/src/tree.js
+++ b/src/tree.js
@@ -15,6 +15,7 @@ import thunk from './thunk';
 import types, { params, toType } from './types';
 import $ from './utils/chain';
 import { keep, reveal } from './utils/secret';
+import values from './values';
 
 const { assign, defineProperties } = Object;
 
@@ -169,7 +170,7 @@ export default class Tree {
   }
 
   get isSimple() {
-    return isSimple(this.Type);
+    return isSimple(this.Type) && !values(this.children).some(tree => tree.isSimple);
   }
 
   get isRoot() {

--- a/src/tree.js
+++ b/src/tree.js
@@ -127,11 +127,11 @@ export class Microstate {
 
 export default class Tree {
 
-  static from(value) {
+  static from(value, T = types.Any) {
     if (value && value instanceof Microstate) {
       return reveal(value);
     } else if (value) {
-      return new Tree({ value, Type: value.constructor });
+      return new Tree({ value, Type: T === types.Any ? value.constructor : T});
     } else {
       return new Tree({ value });
     }

--- a/src/types/object.js
+++ b/src/types/object.js
@@ -11,7 +11,7 @@ class ObjectType {
   assign(props = {}) {
     return transform((children, T) => {
       return foldl((children, key) => {
-        children[key] = new Tree({ Type: T, value: props[key] });
+        children[key] = Tree.from(props[key], T);
         return children;
       }, Object.assign({}, children), Object.keys(props));
     }, this);
@@ -23,7 +23,7 @@ class ObjectType {
         return children
       } else  {
         return Object.assign({}, children, {
-          [key]: new Tree({ Tree: T, value })
+          [key]: Tree.from(value, T)
         })
       }
     }, this);

--- a/src/types/object.js
+++ b/src/types/object.js
@@ -3,6 +3,8 @@ import { parameterized, params } from './parameters0';
 import Any from './any';
 import Tree from '../tree';
 
+const { assign, keys } = Object;
+
 class ObjectType {
   initialize(value = {}) {
     return value;
@@ -13,7 +15,7 @@ class ObjectType {
       return foldl((children, key) => {
         children[key] = Tree.from(props[key], T);
         return children;
-      }, Object.assign({}, children), Object.keys(props));
+      }, assign({}, children), keys(props));
     }, this);
   }
 
@@ -22,7 +24,7 @@ class ObjectType {
       if (children[key] && children[key].value === value) {
         return children
       } else  {
-        return Object.assign({}, children, {
+        return assign({}, children, {
           [key]: Tree.from(value, T)
         })
       }

--- a/src/types/object.js
+++ b/src/types/object.js
@@ -13,7 +13,7 @@ class ObjectType {
   assign(props = {}) {
     return transform((children, T) => {
       return foldl((children, key) => {
-        children[key] = Tree.from(props[key], T);
+        children[key] = Tree.from(props[key], T).graft([key]);
         return children;
       }, assign({}, children), keys(props));
     }, this);
@@ -25,7 +25,7 @@ class ObjectType {
         return children
       } else  {
         return assign({}, children, {
-          [key]: Tree.from(value, T)
+          [key]: Tree.from(value, T).graft([key])
         })
       }
     }, this);

--- a/tests/types/object.test.js
+++ b/tests/types/object.test.js
@@ -146,16 +146,39 @@ describe('put and delete', () => {
   });
 
   describe('putting microstate', () => {
-    beforeEach(() => {
-      object = object.put('name', from('Taras'));
-    });
+    describe('primitive value', () => {
+      beforeEach(() => {
+        object = object.put('name', from('Taras'));
+      });
+  
+      it('has name string', () => {
+        expect(object.name.state).toBe('Taras');
+      });
+  
+      it('has valueOf', () => {
+        expect(object.valueOf()).toEqual({ a: 'b', name: 'Taras' });
+      });
+    })
 
-    it('has name string', () => {
-      expect(object.name.state).toBe('Taras');
-    });
+    describe('composed type', () => {
+      class Person {
+        name = String;
+      }
 
-    it('has valueOf', () => {
-      expect(object.valueOf()).toEqual({ a: 'b', name: 'Taras' });
+      let value;
+      beforeEach(() => {
+        value = create(Person, { name: 'Taras' });
+        object = object.put('taras', value);
+      });
+
+      it('has new type in the state', () => {
+        expect(object.taras.state).toBeInstanceOf(Person);
+        expect(object.state.taras).toBeInstanceOf(Person);
+      });
+
+      it('is stable', () => {
+        expect(object.state.taras).toBe(value.state);
+      });
     });
   });
 

--- a/tests/types/object.test.js
+++ b/tests/types/object.test.js
@@ -1,6 +1,6 @@
 import 'jest';
 
-import { create, from } from 'microstates';
+import { create, from, reveal } from 'microstates';
 
 describe('created without value', () => {
   class Thing {
@@ -118,6 +118,10 @@ describe('created with value', () => {
       it('is stable', () => {
         expect(assigned.state.taras).toBe(value.state);
       });
+
+      it('was grafted into place', () => {
+        expect(reveal(assigned.taras.name).path).toEqual(['taras', 'name']);
+      })
     });
   });
 });

--- a/tests/types/object.test.js
+++ b/tests/types/object.test.js
@@ -80,19 +80,44 @@ describe('created with value', () => {
   });
 
   describe('assign microstate', () => {
-    let assigned;
-    beforeEach(() => {
-      assigned = object.assign({
-        name: from('Taras')
+    describe('primitive type', () => {
+      let assigned;
+      beforeEach(() => {
+        assigned = object.assign({
+          name: from('Taras')
+        });
+      });
+  
+      it('assigned is not a microstate', () => {
+        expect(assigned.name.state).toBe('Taras');
+      });
+  
+      it('microstate value to be part of valueOf', () => {
+        expect(assigned.valueOf()).toEqual({ foo: 'bar', name: 'Taras' });
       });
     });
 
-    it('assigned is not a microstate', () => {
-      expect(assigned.name.state).toBe('Taras');
-    });
+    describe('composed type', () => {
+      class Person {
+        name = String;
+      }
 
-    it('microstate value to be part of valueOf', () => {
-      expect(assigned.valueOf()).toEqual({ foo: 'bar', name: 'Taras' });
+      let assigned, value;
+      beforeEach(() => {
+        value = create(Person, { name: 'Taras' });
+        assigned = object.assign({
+          taras: value 
+        })
+      });
+
+      it('has new type in the state', () => {
+        expect(assigned.taras.state).toBeInstanceOf(Person);
+        expect(assigned.state.taras).toBeInstanceOf(Person);
+      });
+
+      it('is stable', () => {
+        expect(assigned.state.taras).toBe(value.state);
+      });
     });
   });
 });

--- a/tests/types/object.test.js
+++ b/tests/types/object.test.js
@@ -1,6 +1,6 @@
 import 'jest';
 
-import { create } from 'microstates';
+import { create, from } from 'microstates';
 
 describe('created without value', () => {
   class Thing {
@@ -78,15 +78,32 @@ describe('created with value', () => {
       });
     });
   });
+
+  describe('assign microstate', () => {
+    let assigned;
+    beforeEach(() => {
+      assigned = object.assign({
+        name: from('Taras')
+      });
+    });
+
+    it('assigned is not a microstate', () => {
+      expect(assigned.name.state).toBe('Taras');
+    });
+
+    it('microstate value to be part of valueOf', () => {
+      expect(assigned.valueOf()).toEqual({ foo: 'bar', name: 'Taras' });
+    });
+  });
 });
 
 describe('put and delete', () => {
-  let object, put, deleted
+  let object;
   beforeEach(() => {
     object = create(Object, {a: 'b'});
   })
 
-  describe('puting a value or two', function() {
+  describe('putting a value or two', function() {
     beforeEach(function() {
       object = object.put('w', 'x').put('y', 'z');
     });
@@ -101,7 +118,20 @@ describe('put and delete', () => {
         expect(object.valueOf()).toMatchObject({a: 'b', y: 'z'})
       });
     });
+  });
 
+  describe('putting microstate', () => {
+    beforeEach(() => {
+      object = object.put('name', from('Taras'));
+    });
+
+    it('has name string', () => {
+      expect(object.name.state).toBe('Taras');
+    });
+
+    it('has valueOf', () => {
+      expect(object.valueOf()).toEqual({ a: 'b', name: 'Taras' });
+    });
   });
 
 })


### PR DESCRIPTION
This PR allows to pass Microstates when performing `Object.assign` and `Object.put` transitions. This enable use case where the microstate becomes populated over time. In Redux world, this would be equivalent to lazy loading reducers into a redux store.

Let's say you have an application that lazy loads pages and you have a microstate that represents the state of each page. To lazy load a microstate, you would something like this,

```js
let store = Microstate.from({});

// when component renders add the page into the microstate
store.put('page1', create(PageOne, {});
```

