### PR TITLE
Attach map to Microstate class

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import './typeclasses';
 import { Microstate } from './tree';
 
 export default Microstate;
-export const { create } = Microstate;
+export const { create, map } = Microstate;
 export { reveal } from './utils/secret';
 export { default as types } from './types';
 

--- a/src/tree.js
+++ b/src/tree.js
@@ -77,6 +77,10 @@ export class Microstate {
     return append(this, map(child => child.microstate, tree.children));
   }
 
+  static map(fn, microstate) {
+    return fn(reveal(microstate)).microstate
+  }
+
   static from(value) {
     return Tree.from(value).microstate;
   }

--- a/src/typeclasses.js
+++ b/src/typeclasses.js
@@ -3,13 +3,8 @@ import lensPath from 'ramda/src/lensPath';
 import lset from 'ramda/src/set';
 import keys from './keys';
 import Tree, { Microstate, stateFromTree } from './tree';
-import { reveal } from './utils/secret';
 
-Functor.instance(Microstate, {
-  map(fn, microstate) {
-    return fn(reveal(microstate)).microstate;
-  }
-});
+Functor.instance(Microstate, { map: Microstate.map });
 
 /**
  * Tree Functor allows a developer to map a tree without changing

--- a/tests/tree.test.js
+++ b/tests/tree.test.js
@@ -867,7 +867,7 @@ describe('Microstate', () => {
         boolean = Microstate.create(Boolean, true);
         beforeTransition = jest.fn();
         afterTransition = jest.fn();
-        mapped = map(tree => tree.use(next => (microstate, transition, args) => {
+        mapped = Microstate.map(tree => tree.use(next => (microstate, transition, args) => {
           beforeTransition(microstate, transition, args);
           let result = next(microstate, transition, args);
           afterTransition(result);


### PR DESCRIPTION
Adding middleware to microstates is expected to be a common operation that library creators will have to perform. Currently, to use map we require installing funcadelic library. This PR makes it possible to import the map operation without explicitly adding funcadelic under the hood. 

```js
import { map, from } from 'microstates';

const store = map(tree => tree.use(middleware), from({});
```