### PR TITLE
Upgraded funcadelic to 0.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lint": "eslint src"
   },
   "dependencies": {
-    "funcadelic": "0.4.2",
+    "funcadelic": "0.4.3",
     "get-prototype-descriptors": "0.6.0",
     "memoize-getters": "1.1.0",
     "ramda": "^0.25.0",


### PR DESCRIPTION
This new version of funcadelic is not using `lodash.curry` which saves about 2.5kB gzipped.