### PR TITLE
Don't transpile classes in CJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,8 @@
     "dist",
     "README.md"
   ],
-  "main": "dist/microstates.umd.js",
-  "module": "dist/microstates.js",
-  "browser": "dist/microstates.umd.js",
+  "main": "dist/microstates.cjs.js",
+  "module": "dist/microstates.es.js",
   "repository": "git+ssh://git@github.com/microstates/microstates.js.git",
   "scripts": {
     "prepare": "npm run build",
@@ -70,7 +69,7 @@
     ],
     "globalSetup": "./scripts/build.js",
     "collectCoverageFrom": [
-      "dist/microstates.umd.js"
+      "dist/microstates.cjs.js"
     ],
     "testRegex": "(/tests/.*|\\.(test|spec))\\.(js)$",
     "moduleFileExtensions": [
@@ -79,6 +78,9 @@
     ],
     "watchPathIgnorePatterns": [
       "<rootDir>/dist/"
-    ]
+    ],
+    "moduleNameMapper": {
+      "microstates": "<rootDir>/dist/microstates.es.js"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "funcadelic": "0.5.0",
     "get-prototype-descriptors": "0.6.0",
     "memoize-getters": "1.1.0",
-    "ramda": "^0.25.0",
     "symbol-observable": "1.2.0"
   },
   "devDependencies": {
@@ -65,7 +64,8 @@
     "rollup-plugin-node-resolve": "3.3.0",
     "rollup-plugin-replace": "2.0.0",
     "rxjs": "6.1.0",
-    "standard-version": "^4.2.0"
+    "standard-version": "^4.2.0",
+    "ramda": "^0.25.0"
   },
   "jest": {
     "setupFiles": [
@@ -85,6 +85,9 @@
     ],
     "moduleNameMapper": {
       "microstates": "<rootDir>/dist/microstates.es.js"
-    }
+    },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(ramda)/)"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "rollup-plugin-commonjs": "9.1.3",
     "rollup-plugin-filesize": "2.0.0",
     "rollup-plugin-node-resolve": "3.3.0",
+    "rollup-plugin-replace": "2.0.0",
     "rxjs": "6.1.0",
     "standard-version": "^4.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     ],
     "globalSetup": "./scripts/build.js",
     "collectCoverageFrom": [
-      "dist/microstates.cjs.js"
+      "dist/microstates.es.js"
     ],
     "testRegex": "(/tests/.*|\\.(test|spec))\\.(js)$",
     "moduleFileExtensions": [

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "funcadelic": "0.5.0",
     "get-prototype-descriptors": "0.6.0",
     "memoize-getters": "1.1.0",
-    "symbol-observable": "1.2.0"
+    "symbol-observable": "1.2.0",
+    "ramda": "^0.25.0"
   },
   "devDependencies": {
     "@babel/core": "7.0.0-beta.44",
@@ -64,8 +65,7 @@
     "rollup-plugin-node-resolve": "3.3.0",
     "rollup-plugin-replace": "2.0.0",
     "rxjs": "6.1.0",
-    "standard-version": "^4.2.0",
-    "ramda": "^0.25.0"
+    "standard-version": "^4.2.0"
   },
   "jest": {
     "setupFiles": [

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   ],
   "main": "dist/microstates.cjs.js",
   "module": "dist/microstates.es.js",
+  "browser": "dist/microstates.umd.js",
   "repository": "git+ssh://git@github.com/microstates/microstates.js.git",
   "scripts": {
     "prepare": "npm run build",
@@ -57,9 +58,11 @@
     "prettier": "^1.10.2",
     "pretty-error": "2.1.1",
     "pretty-format": "22.1.0",
-    "rollup": "^0.53.0",
+    "rollup": "0.60.1",
     "rollup-plugin-babel": "^4.0.0-beta.0",
-    "rollup-plugin-filesize": "1.5.0",
+    "rollup-plugin-commonjs": "9.1.3",
+    "rollup-plugin-filesize": "2.0.0",
+    "rollup-plugin-node-resolve": "3.3.0",
     "rxjs": "6.1.0",
     "standard-version": "^4.2.0"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,7 @@ const babel = require("rollup-plugin-babel");
 const filesize = require("rollup-plugin-filesize");
 const resolve = require("rollup-plugin-node-resolve");
 const commonjs = require("rollup-plugin-commonjs");
+const replace = require("rollup-plugin-replace");
 const pkg = require("./package.json");
 
 const external = [
@@ -32,24 +33,27 @@ const babelPlugin = babel({
 
 module.exports = [
   {
-		input: 'src/nodules.js',
-		output: {
-			name: 'microstates',
-			file: pkg.browser,
-      format: 'umd',
+    input: "src/nodules.js",
+    output: {
+      name: "microstates",
+      file: pkg.browser,
+      format: "umd",
       sourcemap: true
-		},
-		plugins: [
+    },
+    plugins: [
       babelPlugin,
       resolve(),
-      commonjs(), 
+      commonjs(),
+      replace({
+        'process.env.NODE_ENV': JSON.stringify('production')
+      }),
       filesize({
         render(opt, size, gzip, bundle) {
           return `Built: ${bundle.file} ( size: ${size}, gzip: ${gzip})`;
         }
       })
-		]
-	},
+    ]
+  },
   {
     input: "src/nodules.js",
     external,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,11 +10,11 @@ const external = [
   "symbol-observable",
   "get-prototype-descriptors",
   "memoize-getters",
-  "ramda/src/lensPath",
-  "ramda/src/set",
-  "ramda/src/lens",
-  "ramda/src/over",
-  "ramda/src/view"
+  "ramda/es/lensPath",
+  "ramda/es/set",
+  "ramda/es/lens",
+  "ramda/es/over",
+  "ramda/es/view"
 ];
 
 const babelPlugin = babel({

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,13 @@ const commonjs = require("rollup-plugin-commonjs");
 const replace = require("rollup-plugin-replace");
 const pkg = require("./package.json");
 
+const ramda = [
+  "ramda/es/lensPath",
+  "ramda/es/over",
+  "ramda/es/set",
+  "ramda/es/view"
+]
+
 const external = [
   "funcadelic",
   "symbol-observable",
@@ -58,6 +65,12 @@ module.exports = [
       sourcemap: true
     },
     plugins: [
+      replace({
+        "import lensPath from 'ramda/es/lensPath'": "const {lensPath} from 'ramda/src/lensPath'",
+        "import lset from 'ramda/es/set'": "const {set: lset} from 'ramda/src/set'",
+        "import view from 'ramda/es/view'": "const {view} from 'ramda/src/view'",
+        "import over from 'ramda/es/over'": "const {over} from 'ramda/src/over'"
+      }),
       resolve(),
       babel({
         babelrc: false,
@@ -84,7 +97,7 @@ module.exports = [
   },
   {
     input: "src/index.js",
-    external,
+    external: [...external, ...ramda],
     output: { file: pkg.module, format: "es", sourcemap: true },
     plugins: [
       resolve(),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,12 +9,7 @@ const external = [
   "funcadelic",
   "symbol-observable",
   "get-prototype-descriptors",
-  "memoize-getters",
-  "ramda/es/lensPath",
-  "ramda/es/set",
-  "ramda/es/lens",
-  "ramda/es/over",
-  "ramda/es/view"
+  "memoize-getters"
 ];
 
 const babelPlugin = babel({
@@ -63,6 +58,7 @@ module.exports = [
       sourcemap: true
     },
     plugins: [
+      resolve(),
       babel({
         babelrc: false,
         comments: false,
@@ -91,6 +87,7 @@ module.exports = [
     external,
     output: { file: pkg.module, format: "es", sourcemap: true },
     plugins: [
+      resolve(),
       babelPlugin,
       filesize({
         render(opt, size, gzip, bundle) {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,54 +2,74 @@ const babel = require("rollup-plugin-babel");
 const filesize = require("rollup-plugin-filesize");
 const pkg = require("./package.json");
 
-const { keys } = Object;
+const external = [
+  "funcadelic",
+  "symbol-observable",
+  "get-prototype-descriptors",
+  "memoize-getters",
+  "ramda/src/lensPath",
+  "ramda/src/set",
+  "ramda/src/lens",
+  "ramda/src/over",
+  "ramda/src/view"
+];
 
-const globals = {
-  funcadelic: "funcadelic",
-  "ramda/src/over": "R.over",
-  "ramda/src/lens": "R.lens",
-  "ramda/src/view": "R.view",
-  "ramda/src/set": "R.set",
-  "ramda/src/lensPath": "R.lensPath",
-  "symbol-observable": "SymbolObservable",
-  "get-prototype-descriptors": "getPrototypeDescriptors",
-  "memoize-getters": "memoizeGetters"
-};
-
-module.exports = {
-  input: "src/index.js",
-  external: keys(globals),
-  output: [
-    {
-      file: pkg.browser,
-      format: "umd",
-      name: "Microstates",
-      globals,
-      exports: "named",
+module.exports = [
+  {
+    input: "src/nodules.js",
+    external,
+    output: {
+      file: pkg.main,
+      format: "cjs",
       sourcemap: true
     },
-    { file: pkg.module, format: "es", sourcemap: true }
-  ],
-  plugins: [
-    babel({
-      babelrc: false,
-      comments: false,
-      plugins: [
-        "@babel/plugin-proposal-class-properties"
-      ],
-      presets: [
-        [
-          "@babel/preset-env",
-          {
-            modules: false
-          }
+    plugins: [
+      babel({
+        babelrc: false,
+        comments: false,
+        plugins: ["@babel/plugin-proposal-class-properties"],
+        presets: [
+          [
+            "@babel/preset-env",
+            {
+              targets: {
+                node: "6"
+              },
+              modules: false
+            }
+          ]
         ]
-      ]
-    }),
-    filesize({
-      render(opt, size, gzip, bundle) {
-        return `Built: ${bundle.file} ( size: ${size}, gzip: ${gzip})`;
-      }
-    })
-  ]
-};
+      }),
+      filesize({
+        render(opt, size, gzip, bundle) {
+          return `Built: ${bundle.file} ( size: ${size}, gzip: ${gzip})`;
+        }
+      })
+    ]
+  },
+  {
+    input: "src/index.js",
+    external,
+    output: { file: pkg.module, format: "es", sourcemap: true },
+    plugins: [
+      babel({
+        babelrc: false,
+        comments: false,
+        plugins: ["@babel/plugin-proposal-class-properties"],
+        presets: [
+          [
+            "@babel/preset-env",
+            {
+              modules: false
+            }
+          ]
+        ]
+      }),
+      filesize({
+        render(opt, size, gzip, bundle) {
+          return `Built: ${bundle.file} ( size: ${size}, gzip: ${gzip})`;
+        }
+      })
+    ]
+  }
+];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,7 @@
 const babel = require("rollup-plugin-babel");
 const filesize = require("rollup-plugin-filesize");
+const resolve = require("rollup-plugin-node-resolve");
+const commonjs = require("rollup-plugin-commonjs");
 const pkg = require("./package.json");
 
 const external = [
@@ -14,7 +16,40 @@ const external = [
   "ramda/src/view"
 ];
 
+const babelPlugin = babel({
+  babelrc: false,
+  comments: false,
+  plugins: ["@babel/plugin-proposal-class-properties"],
+  presets: [
+    [
+      "@babel/preset-env",
+      {
+        modules: false
+      }
+    ]
+  ]
+});
+
 module.exports = [
+  {
+		input: 'src/nodules.js',
+		output: {
+			name: 'microstates',
+			file: pkg.browser,
+      format: 'umd',
+      sourcemap: true
+		},
+		plugins: [
+      babelPlugin,
+      resolve(),
+      commonjs(), 
+      filesize({
+        render(opt, size, gzip, bundle) {
+          return `Built: ${bundle.file} ( size: ${size}, gzip: ${gzip})`;
+        }
+      })
+		]
+	},
   {
     input: "src/nodules.js",
     external,
@@ -52,19 +87,7 @@ module.exports = [
     external,
     output: { file: pkg.module, format: "es", sourcemap: true },
     plugins: [
-      babel({
-        babelrc: false,
-        comments: false,
-        plugins: ["@babel/plugin-proposal-class-properties"],
-        presets: [
-          [
-            "@babel/preset-env",
-            {
-              modules: false
-            }
-          ]
-        ]
-      }),
+      babelPlugin,
       filesize({
         render(opt, size, gzip, bundle) {
           return `Built: ${bundle.file} ( size: ${size}, gzip: ${gzip})`;

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,18 +1,16 @@
 const rollup = require("rollup");
 const config = require("../rollup.config");
-const PrettyError = require('pretty-error');
+const PrettyError = require("pretty-error");
 const pe = new PrettyError();
 pe.skipNodeFiles();
-pe.skipPackage('rollup');
+pe.skipPackage("rollup");
 
 module.exports = function() {
   console.log("\n"); // eslint-disable-line
   // create a bundle
-  return rollup
-    .rollup(config)
-    .then(bundle => {
-      let built = config.output.map(options => bundle.write(options));
-      return Promise.all(built);
-    })
-    .catch(e => console.log(pe.render(e))); // eslint-disable-line
+  return Promise.all(
+    config.map(config =>
+      rollup.rollup(config).then(bundle => bundle.write(config.output))
+    )
+  ).catch(e => console.log(pe.render(e))); // eslint-disable-line
 };

--- a/src/nodules.js
+++ b/src/nodules.js
@@ -1,0 +1,13 @@
+import './typeclasses';
+
+import { Microstate } from './tree';
+export { Microstate };
+
+export const create = Microstate.create;
+export const map = Microstate.map;
+
+export { reveal } from './utils/secret';
+
+export { default as types } from './types';
+export { default as Tree } from './tree';
+export { parameterized } from './types/parameters.js';

--- a/src/tree.js
+++ b/src/tree.js
@@ -1,11 +1,11 @@
 import { append, flatMap, foldl, foldr, map, stable } from 'funcadelic';
 import getPrototypeDescriptors from 'get-prototype-descriptors';
 import memoizeGetters from 'memoize-getters';
-import lens from 'ramda/src/lens';
-import lensPath from 'ramda/src/lensPath';
-import over from 'ramda/src/over';
-import lset from 'ramda/src/set';
-import view from 'ramda/src/view';
+import lens from 'ramda/es/lens';
+import lensPath from 'ramda/es/lensPath';
+import over from 'ramda/es/over';
+import lset from 'ramda/es/set';
+import view from 'ramda/es/view';
 import SymbolObservable from "symbol-observable";
 import desugar from './desugar';
 import isSimple from './is-simple';

--- a/src/typeclasses.js
+++ b/src/typeclasses.js
@@ -1,6 +1,6 @@
 import { Functor, Monad, map } from 'funcadelic';
-import lensPath from 'ramda/src/lensPath';
-import lset from 'ramda/src/set';
+import lensPath from 'ramda/es/lensPath';
+import lset from 'ramda/es/set';
 import keys from './keys';
 import Tree, { Microstate, stateFromTree } from './tree';
 

--- a/tests/tree.test.js
+++ b/tests/tree.test.js
@@ -2,9 +2,9 @@ import 'jest';
 
 import Microstate, { Tree, reveal, types } from 'microstates';
 import { flatMap, map, append } from 'funcadelic';
-import view from 'ramda/src/view';
-import set from 'ramda/src/set';
-import over from 'ramda/src/over';
+import view from 'ramda/es/view';
+import set from 'ramda/es/set';
+import over from 'ramda/es/over';
 import { resolveType, stabilizeClass, transitionsClass } from '../src/tree';
 
 const { assign } = Object;


### PR DESCRIPTION
This PR changes main to point to cjs built file which no longer transpiles es6 classes. This is done to prevent conflicts  between babel transpiler and native classes. ES6 classes remain unchanged.

This PR now includes UMD build that's linked to browser entry. This build has all dependencies necessary to use microstates. It's primarily for EmberCLI integration.

Related #123