### PR TITLE
Make it possible to export a list of types from a tree

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -10,6 +10,7 @@ import SymbolObservable from "symbol-observable";
 import desugar from './desugar';
 import isSimple from './is-simple';
 import keys from './keys';
+import values from './values';
 import shallowDiffers from './shallow-differs';
 import thunk from './thunk';
 import types, { params, toType } from './types';
@@ -69,6 +70,21 @@ export const stabilizeClass = stable(function stabilizeClass(Type) {
   return memoizeGetters(ImmutableState);
 });
 
+/**
+ * Get map of all Types in the tree. The Types will be included
+ * for trees that have a value.
+ * @param {Tree} tree 
+ * @returns {[Type.name]: Type}
+ */
+function getTypes(tree) {
+  let { InitialType: Type } = tree.meta;
+  let initial = { [Type.name]: Type };
+  let children = 
+    values(tree.children)
+    .filter(tree => tree.value !== undefined);
+
+  return foldl((acc, tree) => assign(acc, getTypes(tree)), initial, children)
+}
 export class Microstate {
 
   constructor(tree) {
@@ -199,6 +215,10 @@ export default class Tree {
 
   get children() {
     return this.meta.children.value;
+  }
+
+  get types() {
+    return getTypes(this);
   }
 
   is(tree) {

--- a/tests/tree.test.js
+++ b/tests/tree.test.js
@@ -160,6 +160,21 @@ describe('Tree', () => {
     moreThings = new Tree({ Type: Things, value: { a: { name: 'A', more: { a: { name: 'AA' } } }, b: { name: 'B' } } })
   });
 
+  describe('types', () => {
+    it('accumulates type information for shallow trees', () => {
+      expect(a.types).toMatchObject({
+        String
+      });
+    });
+    it('accumulates types information for deeply nested trees', () => {
+      expect(moreThings.types).toMatchObject({
+        Thing,
+        String,
+        Things
+      })
+    });
+  });
+
   describe('Functor', () => {
     it('is lazy', () => {
       let fn = jest.fn(tree => tree);


### PR DESCRIPTION
This PR makes it possible to get a map of all Types in a tree. This is useful for deserialization to match names of Types to actual Type constructors.