### PR TITLE
Added formatting to microstate types

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -38,7 +38,11 @@ const defaultMiddleware = (localMicrostate, transition, args) => {
 };
 
 export const transitionsClass = stable(function transitionsClass(Type) {
-  class Transitions extends Microstate {}
+  class Transitions extends Microstate {
+    static get name() {
+      return `Microstate<${Type.name}>`;
+    }
+  }
 
   let descriptors = Type === types.Any ? getPrototypeDescriptors(types.Any) : assign(getPrototypeDescriptors(resolveType(Type)), getPrototypeDescriptors(types.Any))
 
@@ -66,6 +70,10 @@ export const resolveType = stable(function resolveType(Type) {
 export const stabilizeClass = stable(function stabilizeClass(Type) {
   class ImmutableState extends resolveType(Type) {
     get state() { return this }
+
+    static get name() {
+      return `Immutable<${Type.name}>`;
+    }
   }
   return memoizeGetters(ImmutableState);
 });

--- a/src/tree.js
+++ b/src/tree.js
@@ -40,7 +40,7 @@ const defaultMiddleware = (localMicrostate, transition, args) => {
 export const transitionsClass = stable(function transitionsClass(Type) {
   class Transitions extends Microstate {
     static get name() {
-      return `Microstate<${Type.name}>`;
+      return `Transitions<${Type.name}>`;
     }
   }
 
@@ -72,7 +72,7 @@ export const stabilizeClass = stable(function stabilizeClass(Type) {
     get state() { return this }
 
     static get name() {
-      return `Immutable<${Type.name}>`;
+      return `State<${Type.name}>`;
     }
   }
   return memoizeGetters(ImmutableState);

--- a/tests/tree.test.js
+++ b/tests/tree.test.js
@@ -1233,11 +1233,21 @@ describe('stabilizeClass', () => {
     let Type = [String];
     expect(stabilizeClass(Type)).toBe(stabilizeClass(Type));
   });
+
+  it('has Immutable<Type> name', () => {
+    class Foo {}
+    expect(stabilizeClass(Foo).name).toBe('Immutable<Foo>');
+  });
 });
 
 describe('transitionsClass', () => {
   it('is stable for sugar type', () => {
     let Type = [String];
     expect(transitionsClass(Type)).toBe(transitionsClass(Type));
+  });
+
+  it('has Microstate<Type> name', () => {
+    class Foo {}
+    expect(transitionsClass(Foo).name).toBe('Microstate<Foo>');
   });
 });

--- a/tests/tree.test.js
+++ b/tests/tree.test.js
@@ -1236,7 +1236,7 @@ describe('stabilizeClass', () => {
 
   it('has Immutable<Type> name', () => {
     class Foo {}
-    expect(stabilizeClass(Foo).name).toBe('Immutable<Foo>');
+    expect(stabilizeClass(Foo).name).toBe('State<Foo>');
   });
 });
 
@@ -1248,6 +1248,6 @@ describe('transitionsClass', () => {
 
   it('has Microstate<Type> name', () => {
     class Foo {}
-    expect(transitionsClass(Foo).name).toBe('Microstate<Foo>');
+    expect(transitionsClass(Foo).name).toBe('Transitions<Foo>');
   });
 });


### PR DESCRIPTION
This PR makes it possible display type as `Microstate<Type>` for microstates. It'll be helpful when people look at microstates in object inspectors like Redux Dev Tools.

<img width="464" alt="screen shot 2018-06-06 at 9 41 26 pm" src="https://user-images.githubusercontent.com/74687/41078585-8fb81c70-69d2-11e8-846c-3b41dcfc9570.png">
