### PR TITLE
[BREAKING] exposed use for middleware and map for array mapping

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import './typeclasses';
 import { Microstate } from './tree';
 
 export default Microstate;
-export const { create, from, map } = Microstate;
+export const { create, from, use, map } = Microstate;
 export { reveal } from './utils/secret';
 export { default as types } from './types';
 

--- a/src/tree.js
+++ b/src/tree.js
@@ -79,7 +79,11 @@ export class Microstate {
   }
 
   static map(fn, microstate) {
-    return fn(reveal(microstate)).microstate
+    return map(tree => fn(tree.microstate), reveal(microstate).children);
+  }
+
+  static use(middleware, microstate) {
+    return map(tree => tree.use(middleware), microstate);
   }
 
   static from(value) {
@@ -115,11 +119,11 @@ export class Microstate {
       subscribe(observer) {
         let next = observer.call ? observer : observer.next.bind(observer);
 
-        let mapped = map(tree => tree.use(middleware => (...args) => {
+        let mapped = Microstate.use(middleware => (...args) => {
           let microstate = middleware(...args);
           next(microstate);
           return microstate;
-        }), microstate);
+        }, microstate);
 
         next(mapped);
       },

--- a/src/typeclasses.js
+++ b/src/typeclasses.js
@@ -3,8 +3,13 @@ import lensPath from 'ramda/src/lensPath';
 import lset from 'ramda/src/set';
 import keys from './keys';
 import Tree, { Microstate, stateFromTree } from './tree';
+import { reveal } from './utils/secret';
 
-Functor.instance(Microstate, { map: Microstate.map });
+Functor.instance(Microstate, { 
+  map(fn, microstate) {
+    return fn(reveal(microstate)).microstate
+  } 
+});
 
 /**
  * Tree Functor allows a developer to map a tree without changing

--- a/tests/microstate.test.js
+++ b/tests/microstate.test.js
@@ -1,5 +1,5 @@
 import 'jest';
-import { create } from 'microstates';
+import Microstate, { create, map } from 'microstates';
 
 it('exports create', function() {
   expect(create).toBeInstanceOf(Function);
@@ -26,5 +26,26 @@ describe('valueOf', () => {
   });
   it('is not enumerable', () => {
     expect(Object.keys(ms).indexOf('valueOf')).toBe(-1);
+  });
+});
+
+describe('map', () => {
+  let items, mapped;
+  beforeEach(() => {
+    items = create([Number], [1, 2, 3]);
+    mapped = map(microstate => microstate, items);
+  });
+  it('returns an array', () => {
+    expect(Array.isArray(mapped)).toBe(true);
+  });
+  it('has a microstate as each item', () => {
+    expect(mapped[0]).toBeInstanceOf(Microstate);
+    expect(mapped[1]).toBeInstanceOf(Microstate);
+    expect(mapped[2]).toBeInstanceOf(Microstate);        
+  });
+  it('has a microstate has a state', () => {
+    expect(mapped[0].state).toBe(1);
+    expect(mapped[1].state).toBe(2);
+    expect(mapped[2].state).toBe(3);        
   });
 });

--- a/tests/microstate.test.js
+++ b/tests/microstate.test.js
@@ -29,7 +29,7 @@ describe('valueOf', () => {
   });
 });
 
-describe('map', () => {
+describe('map array', () => {
   let items, mapped;
   beforeEach(() => {
     items = create([Number], [1, 2, 3]);
@@ -47,5 +47,26 @@ describe('map', () => {
     expect(mapped[0].state).toBe(1);
     expect(mapped[1].state).toBe(2);
     expect(mapped[2].state).toBe(3);        
+  });
+});
+
+describe('map object', () => {
+  let items, mapped;
+  beforeEach(() => {
+    items = create({Number}, { one: 1, two: 2, three: 3 });
+    mapped = map(microstate => microstate, items);
+  });
+  it('returns a regular object, not microstate', () => {
+    expect(mapped).not.toBeInstanceOf(Microstate);
+  });
+  it('has composed states', () => {
+    expect(mapped.one).toBeInstanceOf(Microstate);
+    expect(mapped.two).toBeInstanceOf(Microstate);
+    expect(mapped.three).toBeInstanceOf(Microstate);
+  });
+  it('has values', () => {
+    expect(mapped.one.state).toBe(1);
+    expect(mapped.two.state).toBe(2);
+    expect(mapped.three.state).toBe(3);
   });
 });

--- a/tests/tree.test.js
+++ b/tests/tree.test.js
@@ -867,7 +867,7 @@ describe('Microstate', () => {
         boolean = Microstate.create(Boolean, true);
         beforeTransition = jest.fn();
         afterTransition = jest.fn();
-        mapped = Microstate.map(tree => tree.use(next => (microstate, transition, args) => {
+        mapped = map(tree => tree.use(next => (microstate, transition, args) => {
           beforeTransition(microstate, transition, args);
           let result = next(microstate, transition, args);
           afterTransition(result);


### PR DESCRIPTION
Previously, `map` function was used to gain access to the underlying tree, usually to install middleware. This became a problem when we realized that we needed a way to map arrays that did not cause a transition but allowed to render components instead. 

This PR introduces `use` function on the Microstate class and changes map function to use for array mapping. 

Now to install middleware,

```js
import { use, create } from 'microstates';

let microstates = create([Number], [1, 2, 3]);

let middleware = next => (...args) => next(...args);
let withMiddleware = use(middleware, microstates);
```

This allows map to be used for mapping to components,

```jsx
import { map, create } from 'microstates';

let microstates = create([Number], [1, 2, 3]);

map(microstate => <li>{microstates.state}</li>, microstates);
```

Closes #129 