### PR TITLE
[BREAKING] No longer caching getters automatically 😭

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "funcadelic": "0.5.0",
     "get-prototype-descriptors": "0.6.0",
-    "memoize-getters": "1.1.0",
     "ramda": "^0.25.0",
     "symbol-observable": "1.2.0"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,7 +13,6 @@ const globals = {
   "ramda/src/lensPath": "R.lensPath",
   "symbol-observable": "SymbolObservable",
   "get-prototype-descriptors": "getPrototypeDescriptors",
-  "memoize-getters": "memoizeGetters"
 };
 
 module.exports = {

--- a/tests/computed-properties.test.js
+++ b/tests/computed-properties.test.js
@@ -32,8 +32,3 @@ it('is computed', () => {
 it('should not have getters in valueOf after custom transition', () => {
   expect(ms.toUpperCase().valueOf()).not.toHaveProperty('fullName');
 });
-
-it('computed properties are stable', () => {
-  expect(ms.state.birthDate).toBeInstanceOf(Date);
-  expect(ms.state.birthDate).toBe(ms.state.birthDate);
-});

--- a/tests/tree.test.js
+++ b/tests/tree.test.js
@@ -5,7 +5,7 @@ import { flatMap, map, append } from 'funcadelic';
 import view from 'ramda/src/view';
 import set from 'ramda/src/set';
 import over from 'ramda/src/over';
-import { resolveType, stabilizeClass, transitionsClass } from '../src/tree';
+import { resolveType, transitionsClass } from '../src/tree';
 
 const { assign } = Object;
 
@@ -32,8 +32,8 @@ describe('from', () => {
     let microstate = tree.microstate;
     expect(tree).toHaveProperty('Type', types.Array);
     expect(microstate[0]).toHaveProperty('increment');
-    expect(microstate[1]).toHaveProperty('increment'); 
-    expect(microstate[2]).toHaveProperty('increment');       
+    expect(microstate[1]).toHaveProperty('increment');
+    expect(microstate[2]).toHaveProperty('increment');
   });
 
   it('parameterized value can be undefined', () => {
@@ -41,9 +41,9 @@ describe('from', () => {
     let microstate = tree.microstate;
     expect(tree).toHaveProperty('Type', types.Array);
     expect(microstate[0]).toHaveProperty('increment');
-    expect(tree.children[1]).toHaveProperty('Type', types.Any); 
-    expect(microstate[1]).toHaveProperty('set'); 
-    expect(microstate[2]).toHaveProperty('increment');  
+    expect(tree.children[1]).toHaveProperty('Type', types.Any);
+    expect(microstate[1]).toHaveProperty('set');
+    expect(microstate[2]).toHaveProperty('increment');
   });
 
   it('converts { hello: world } to { String }', () => {
@@ -171,26 +171,26 @@ describe('Tree', () => {
       beforeEach(() => {
         mapped = map(tree => tree, a);
       });
-  
+
       it('returns an instance of Tree', () => {
         expect(mapped).toBeInstanceOf(Tree);
       });
-  
+
       it('has same type as original', () => {
         expect(mapped.Type).toBe(a.Type);
       });
-  
+
       it('has new meta object', () => {
         expect(mapped.meta).not.toBe(a.meta);
       });
-  
+
       it('has same data because no-op operation', () => {
         expect(mapped.data).toBe(a.data);
       });
-  
+
       it('it has same path', () => {
         expect(mapped.path).toBe(a.path);
-      });  
+      });
     })
 
     describe('chanding path', () => {
@@ -219,7 +219,7 @@ describe('Tree', () => {
             }
           }), a);
         });
-  
+
         it('updates value', () => {
           expect(mapped.value).toBe('hello world');
         });
@@ -238,7 +238,7 @@ describe('Tree', () => {
             }
           }), a);
         });
-  
+
         it('updates value', () => {
           expect(mapped.value).toBe('hello world');
         });
@@ -498,7 +498,7 @@ describe('Tree', () => {
               return tree.assign({
                 data: {
                   value() {
-                    return { 
+                    return {
                       things: [
                         value.things[0],
                         { name: 'Subabaruru' },
@@ -522,7 +522,7 @@ describe('Tree', () => {
         });
 
         it('updated the value on the root', () => {
-          expect(flatMapped.value).toEqual({ 
+          expect(flatMapped.value).toEqual({
             things: [
               { name: 'iPhone' }, { name: 'Subabaruru' }, { name: 'Bicycle' }
             ]
@@ -545,9 +545,9 @@ describe('Tree', () => {
         it('has root on each node', () => {
           expect(flatMapped.children.things.children[2].root).toBe(flatMapped);
           expect(flatMapped.children.things.children[1].root).toBe(flatMapped);
-          expect(flatMapped.children.things.children[0].root).toBe(flatMapped);          
-          expect(flatMapped.children.things.root).toBe(flatMapped);                    
-          expect(flatMapped.root).toBe(flatMapped);                    
+          expect(flatMapped.children.things.children[0].root).toBe(flatMapped);
+          expect(flatMapped.children.things.root).toBe(flatMapped);
+          expect(flatMapped.root).toBe(flatMapped);
         });
 
       });
@@ -561,7 +561,7 @@ describe('Tree', () => {
               return tree.assign({
                 data: {
                   value() {
-                    return { 
+                    return {
                       things: [
                         value.things[0]
                       ]
@@ -575,7 +575,7 @@ describe('Tree', () => {
         });
 
         it('has new value on root', () => {
-          expect(flatMapped.value).toEqual({ 
+          expect(flatMapped.value).toEqual({
             things: [
               { name: 'iPhone' }
             ]
@@ -604,13 +604,13 @@ describe('Tree', () => {
       it('instance is equal to itself', () => {
         expect(a.isEqual(a)).toBe(true);
       });
-  
+
       it('no-op map is equal to itself', () => {
         let mapped = map(tree => tree, a);
         expect(a.isEqual(mapped)).toBe(true);
         expect(mapped.isEqual(a)).toBe(true);
       });
-  
+
       it('no-op flatMap is equal to itself', () => {
         let flatMapped = flatMap(tree => tree, a);
         expect(a.isEqual(flatMapped)).toBe(true);
@@ -837,11 +837,11 @@ describe('Microstate', () => {
         it('has correct root on revealed tree', () => {
           expect(tree.root).toBe(tree);
         });
-  
+
         it('has correct root on tree in unchanged branch', () => {
           expect(motherTree.root).toBe(tree);
         });
-  
+
         it('has correct root on tree in modified branch', () => {
           expect(fatherNameTree.root).toBe(tree);
         });
@@ -1049,43 +1049,43 @@ describe('Microstate', () => {
       class Anonymous extends Session {
         signin() {}
       }
-  
+
       describe('initialize without token', () => {
         let initialized;
         beforeEach(() => {
           initialized = Microstate.create(Session);
         });
-  
+
         it('initilizes into another type', () => {
           expect(initialized.state).toBeInstanceOf(Anonymous);
         });
-  
+
         it('has signin transition', () => {
           expect(initialized.signin).toBeInstanceOf(Function);
         });
-  
+
         describe('calling initialize on initialized microstate', () => {
           let reinitialized;
           beforeEach(() => {
             reinitialized = initialized.initialize({ token: 'foo' });
           });
-  
+
           it('initilizes into Authenticated', () => {
             expect(reinitialized.state).toBeInstanceOf(Authenticated);
           });
         });
       });
-  
+
       describe('initialize with token', () => {
         let initialized;
         beforeEach(() => {
           initialized = Microstate.create(Session, { token: 'SECRET' });
         });
-  
+
         it('initilizes into Authenticated', () => {
           expect(initialized.state).toBeInstanceOf(Authenticated);
         });
-  
+
         it('has signin transition', () => {
           expect(initialized.logout).toBeInstanceOf(Function);
         });
@@ -1106,10 +1106,10 @@ describe('Microstate', () => {
           };
         };
       }
-    
+
       describe('initialization', () => {
         let root;
-        
+
         beforeEach(() => {
           root = Microstate.create(Root, { first: { } });
         });
@@ -1130,7 +1130,7 @@ describe('Microstate', () => {
           beforeEach(() => {
             changed = root.first.second.name.concat("!!!");
           });
-        
+
           it("has result after transition valueOf", () => {
             expect(changed.valueOf()).toEqual({
               first: {
@@ -1140,26 +1140,13 @@ describe('Microstate', () => {
               },
             });
           });
-  
-        });  
+
+        });
       });
     });
   });
 
   describe("State", () => {
-    it('has state alias', () => {
-      class Person {
-        firstName = String;
-        lastName = String;
-        get fullName() {
-          return `${this.state.firstName} ${this.state.lastName}`;
-        }
-      }
-
-      let person = Microstate.create(Person, { firstName: 'Taras', lastName: 'Mankovski' });
-
-      expect(person.state.fullName).toBe('Taras Mankovski');
-    });
     describe("recursive type", () => {
       class Person {
         father = Person;
@@ -1202,7 +1189,7 @@ describe('Microstate', () => {
           expect(person.state.mother).toBeInstanceOf(Person);
         });
         it('composed type without data is undefined', () => {
-          expect(person.state.father).toBeUndefined();          
+          expect(person.state.father).toBeUndefined();
         })
         it('composted types have primivite values', () => {
           expect(person.state.mother.name).toBe('');
@@ -1226,13 +1213,6 @@ describe('resolveType', () => {
     let Type = [String];
     expect(resolveType(Type)).toBe(resolveType(Type));
   })
-});
-
-describe('stabilizeClass', () => {
-  it('is stable for sugar type', () => {
-    let Type = [String];
-    expect(stabilizeClass(Type)).toBe(stabilizeClass(Type));
-  });
 });
 
 describe('transitionsClass', () => {


### PR DESCRIPTION
This is sad, but we decided to remove automatic memoization of getters due to problems that are introduced by extending classes in our library. We will educate our users about the fact that this is possible and we may add this back if it becomes possible. 

Instead of #124 