### PR TITLE
building UMD, CJS and ES files

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "dist",
     "README.md"
   ],
-  "main": "dist/microstates.umd.js",
-  "module": "dist/microstates.js",
+  "main": "dist/microstates.cjs.js",
+  "module": "dist/microstates.es.js",
   "browser": "dist/microstates.umd.js",
   "repository": "git+ssh://git@github.com/microstates/microstates.js.git",
   "scripts": {
@@ -58,9 +58,12 @@
     "prettier": "^1.10.2",
     "pretty-error": "2.1.1",
     "pretty-format": "22.1.0",
-    "rollup": "^0.53.0",
+    "rollup": "0.60.1",
     "rollup-plugin-babel": "^4.0.0-beta.0",
-    "rollup-plugin-filesize": "1.5.0",
+    "rollup-plugin-commonjs": "9.1.3",
+    "rollup-plugin-filesize": "2.0.0",
+    "rollup-plugin-node-resolve": "3.3.0",
+    "rollup-plugin-replace": "2.0.0",
     "rxjs": "6.2.1",
     "standard-version": "^4.2.0"
   },
@@ -70,7 +73,7 @@
     ],
     "globalSetup": "./scripts/build.js",
     "collectCoverageFrom": [
-      "dist/microstates.umd.js"
+      "dist/microstates.es.js"
     ],
     "testRegex": "(/tests/.*|\\.(test|spec))\\.(js)$",
     "moduleFileExtensions": [
@@ -79,6 +82,12 @@
     ],
     "watchPathIgnorePatterns": [
       "<rootDir>/dist/"
+    ],
+    "moduleNameMapper": {
+      "microstates": "<rootDir>/dist/microstates.es.js"
+    },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(ramda)/)"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   ],
   "main": "dist/microstates.cjs.js",
   "module": "dist/microstates.es.js",
-  "browser": "dist/microstates.umd.js",
   "repository": "git+ssh://git@github.com/microstates/microstates.js.git",
   "scripts": {
     "prepare": "npm run build",
@@ -60,7 +59,6 @@
     "pretty-format": "22.1.0",
     "rollup": "0.60.1",
     "rollup-plugin-babel": "^4.0.0-beta.0",
-    "rollup-plugin-commonjs": "9.1.3",
     "rollup-plugin-filesize": "2.0.0",
     "rollup-plugin-node-resolve": "3.3.0",
     "rollup-plugin-replace": "2.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,55 +1,112 @@
 const babel = require("rollup-plugin-babel");
 const filesize = require("rollup-plugin-filesize");
 const pkg = require("./package.json");
+const resolve = require("rollup-plugin-node-resolve");
+const commonjs = require("rollup-plugin-commonjs");
+const replace = require("rollup-plugin-replace");
 
-const { keys } = Object;
+const ramda = [
+  "ramda/es/lensPath",
+  "ramda/es/over",
+  "ramda/es/set",
+  "ramda/es/view"
+]
 
-const globals = {
-  funcadelic: "funcadelic",
-  "ramda/src/over": "R.over",
-  "ramda/src/lens": "R.lens",
-  "ramda/src/view": "R.view",
-  "ramda/src/set": "R.set",
-  "ramda/src/lensPath": "R.lensPath",
-  "symbol-observable": "SymbolObservable",
-  "get-prototype-descriptors": "getPrototypeDescriptors",
-  "invariant": "invariant"
-};
+const external = [
+  "funcadelic",
+  "symbol-observable",
+  "get-prototype-descriptors",
+  "invariant"
+];
 
-module.exports = {
-  input: "src/index.js",
-  external: keys(globals),
-  output: [
-    {
+const babelPlugin = babel({
+  babelrc: false,
+  comments: false,
+  plugins: ["@babel/plugin-proposal-class-properties"],
+  presets: [
+    [
+      "@babel/preset-env",
+      {
+        modules: false
+      }
+    ]
+  ]
+});
+
+module.exports = [
+  {
+    input: "src/nodules.js",
+    output: {
+      name: "microstates",
       file: pkg.browser,
       format: "umd",
-      name: "Microstates",
-      globals,
-      exports: "named",
       sourcemap: true
     },
-    { file: pkg.module, format: "es", sourcemap: true }
-  ],
-  plugins: [
-    babel({
-      babelrc: false,
-      comments: false,
-      plugins: [
-        "@babel/plugin-proposal-class-properties"
-      ],
-      presets: [
-        [
-          "@babel/preset-env",
-          {
-            modules: false
-          }
+    plugins: [
+      babelPlugin,
+      resolve(),
+      commonjs(),
+      replace({
+        'process.env.NODE_ENV': JSON.stringify('production')
+      }),
+      filesize({
+        render(opt, size, gzip, bundle) {
+          return `Built: ${bundle.file} ( size: ${size}, gzip: ${gzip})`;
+        }
+      })
+    ]
+  },
+  {
+    input: "src/nodules.js",
+    external,
+    output: {
+      file: pkg.main,
+      format: "cjs",
+      sourcemap: true
+    },
+    plugins: [
+      replace({
+        "import lensPath from 'ramda/es/lensPath'": "const {lensPath} from 'ramda/src/lensPath'",
+        "import lset from 'ramda/es/set'": "const {set: lset} from 'ramda/src/set'",
+        "import view from 'ramda/es/view'": "const {view} from 'ramda/src/view'",
+        "import over from 'ramda/es/over'": "const {over} from 'ramda/src/over'"
+      }),
+      resolve(),
+      babel({
+        babelrc: false,
+        comments: false,
+        plugins: ["@babel/plugin-proposal-class-properties"],
+        presets: [
+          [
+            "@babel/preset-env",
+            {
+              targets: {
+                node: "6"
+              },
+              modules: false
+            }
+          ]
         ]
-      ]
-    }),
-    filesize({
-      render(opt, size, gzip, bundle) {
-        return `Built: ${bundle.file} ( size: ${size}, gzip: ${gzip})`;
-      }
-    })
-  ]
-};
+      }),
+      filesize({
+        render(opt, size, gzip, bundle) {
+          return `Built: ${bundle.file} ( size: ${size}, gzip: ${gzip})`;
+        }
+      })
+    ]
+  },
+  {
+    input: "src/index.js",
+    external: [...external, ...ramda],
+    output: { file: pkg.module, format: "es", sourcemap: true },
+    plugins: [
+      resolve(),
+      babelPlugin,
+      filesize({
+        render(opt, size, gzip, bundle) {
+          return `Built: ${bundle.file} ( size: ${size}, gzip: ${gzip})`;
+        }
+      })
+    ]
+  }
+];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,6 @@ const babel = require("rollup-plugin-babel");
 const filesize = require("rollup-plugin-filesize");
 const pkg = require("./package.json");
 const resolve = require("rollup-plugin-node-resolve");
-const commonjs = require("rollup-plugin-commonjs");
 const replace = require("rollup-plugin-replace");
 
 const ramda = [
@@ -33,29 +32,13 @@ const babelPlugin = babel({
   ]
 });
 
+const fileSize = filesize({
+  render(opt, size, gzip, bundle) {
+    return `Built: ${bundle.file} ( size: ${size}, gzip: ${gzip})`;
+  }
+});
+
 module.exports = [
-  {
-    input: "src/nodules.js",
-    output: {
-      name: "microstates",
-      file: pkg.browser,
-      format: "umd",
-      sourcemap: true
-    },
-    plugins: [
-      babelPlugin,
-      resolve(),
-      commonjs(),
-      replace({
-        'process.env.NODE_ENV': JSON.stringify('production')
-      }),
-      filesize({
-        render(opt, size, gzip, bundle) {
-          return `Built: ${bundle.file} ( size: ${size}, gzip: ${gzip})`;
-        }
-      })
-    ]
-  },
   {
     input: "src/nodules.js",
     external,
@@ -88,11 +71,7 @@ module.exports = [
           ]
         ]
       }),
-      filesize({
-        render(opt, size, gzip, bundle) {
-          return `Built: ${bundle.file} ( size: ${size}, gzip: ${gzip})`;
-        }
-      })
+      fileSize
     ]
   },
   {
@@ -102,11 +81,7 @@ module.exports = [
     plugins: [
       resolve(),
       babelPlugin,
-      filesize({
-        render(opt, size, gzip, bundle) {
-          return `Built: ${bundle.file} ( size: ${size}, gzip: ${gzip})`;
-        }
-      })
+      fileSize
     ]
   }
 ];

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,18 +1,16 @@
 const rollup = require("rollup");
 const config = require("../rollup.config");
-const PrettyError = require('pretty-error');
+const PrettyError = require("pretty-error");
 const pe = new PrettyError();
 pe.skipNodeFiles();
-pe.skipPackage('rollup');
+pe.skipPackage("rollup");
 
 module.exports = function() {
   console.log("\n"); // eslint-disable-line
   // create a bundle
-  return rollup
-    .rollup(config)
-    .then(bundle => {
-      let built = config.output.map(options => bundle.write(options));
-      return Promise.all(built);
-    })
-    .catch(e => console.log(pe.render(e))); // eslint-disable-line
+  return Promise.all(
+    config.map(config =>
+      rollup.rollup(config).then(bundle => bundle.write(config.output))
+    )
+  ).catch(e => console.log(pe.render(e))); // eslint-disable-line
 };

--- a/src/nodules.js
+++ b/src/nodules.js
@@ -1,0 +1,15 @@
+import './typeclasses';
+
+import { Microstate } from './tree';
+export { Microstate };
+
+export const create = Microstate.create;
+export const map = Microstate.map;
+export const use = Microstate.use;
+export const from = Microstate.from;
+
+export { reveal } from './utils/secret';
+
+export { default as types } from './types';
+export { default as Tree } from './tree';
+export { parameterized } from './types/parameters.js';

--- a/src/tree.js
+++ b/src/tree.js
@@ -1,10 +1,10 @@
 import { append, flatMap, foldl, foldr, map, stable } from 'funcadelic';
 import getPrototypeDescriptors from 'get-prototype-descriptors';
-import lens from 'ramda/src/lens';
-import lensPath from 'ramda/src/lensPath';
-import over from 'ramda/src/over';
-import lset from 'ramda/src/set';
-import view from 'ramda/src/view';
+import lens from 'ramda/es/lens';
+import lensPath from 'ramda/es/lensPath';
+import over from 'ramda/es/over';
+import lset from 'ramda/es/set';
+import view from 'ramda/es/view';
 import SymbolObservable from "symbol-observable";
 import desugar from './desugar';
 import isSimple from './is-simple';

--- a/src/typeclasses.js
+++ b/src/typeclasses.js
@@ -1,6 +1,6 @@
 import { Functor, Monad, map } from 'funcadelic';
-import lensPath from 'ramda/src/lensPath';
-import lset from 'ramda/src/set';
+import lensPath from 'ramda/es/lensPath';
+import lset from 'ramda/es/set';
 import keys from './keys';
 import Tree, { Microstate, stateFromTree } from './tree';
 import { reveal } from './utils/secret';

--- a/tests/tree.test.js
+++ b/tests/tree.test.js
@@ -2,9 +2,9 @@ import 'jest';
 
 import Microstate, { Tree, reveal, types } from 'microstates';
 import { flatMap, map, append } from 'funcadelic';
-import view from 'ramda/src/view';
-import set from 'ramda/src/set';
-import over from 'ramda/src/over';
+import view from 'ramda/es/view';
+import set from 'ramda/es/set';
+import over from 'ramda/es/over';
 import { resolveType, transitionsClass } from '../src/tree';
 
 const { assign } = Object;


### PR DESCRIPTION
This PR fixes the built files in the following way,

1. for ES, import ramda dependencies from es dist
2. for CJS, import ramda dependencies from src
3. strip out process.env.DEV from invariant for UMD
4. use cjs for main
5. use es for modules
6. include all dependencies in UMD
7. ~use UMD for browser entry~
8. removed UMD build