### PR TITLE
Transitions are now auto bound

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -49,11 +49,10 @@ export const transitionsClass = stable(function transitionsClass(Type) {
   let transitions = $(descriptors)
     .filter(({ key, value }) => typeof value.value === 'function' && key !== 'constructor')
     .map(descriptor => ({
-      enumerable: true,
+      enumerable: false,
       configurable: true,
-      value(...args) {
-        // transition that the user is invoking
-        return reveal(this).root.data.middleware(this, descriptor.value, args);
+      get() {
+        return (...args) => reveal(this).root.data.middleware(this, descriptor.value, args);
       }
     }))
     .valueOf();

--- a/src/tree.js
+++ b/src/tree.js
@@ -48,11 +48,17 @@ export const transitionsClass = stable(function transitionsClass(Type) {
 
   let transitions = $(descriptors)
     .filter(({ key, value }) => typeof value.value === 'function' && key !== 'constructor')
-    .map(descriptor => ({
+    .map((descriptor, key) => ({
       enumerable: false,
       configurable: true,
       get() {
-        return (...args) => reveal(this).root.data.middleware(this, descriptor.value, args);
+        let bound = (...args) => reveal(this).root.data.middleware(this, descriptor.value, args);
+        Object.defineProperty(bound, 'name', {
+          value: key,
+          configurable: true,
+          enumerable: false
+        });
+        return bound;
       }
     }))
     .valueOf();

--- a/tests/microstate.test.js
+++ b/tests/microstate.test.js
@@ -70,3 +70,16 @@ describe('map object', () => {
     expect(mapped.three.state).toBe(3);
   });
 });
+
+describe('transitions', () => {
+  let number;
+  beforeEach(() => {
+    number = create(Number, 42);
+  });
+  it('allows to use increment without original object', () => {
+    let { increment } = number;
+    let result = increment();
+    expect(result).toBeInstanceOf(Microstate);
+    expect(result.valueOf()).toBe(43);
+  });
+});

--- a/tests/microstate.test.js
+++ b/tests/microstate.test.js
@@ -72,14 +72,17 @@ describe('map object', () => {
 });
 
 describe('transitions', () => {
-  let number;
+  let number, increment;
   beforeEach(() => {
     number = create(Number, 42);
+    increment = number.increment;
   });
   it('allows to use increment without original object', () => {
-    let { increment } = number;
     let result = increment();
     expect(result).toBeInstanceOf(Microstate);
     expect(result.valueOf()).toBe(43);
+  });
+  it('has name of the function', () => {
+    expect(increment.name).toBe('increment');
   });
 });


### PR DESCRIPTION
This PR changes transitions to be automatically bound. By making these functions bound by default, we are able to easily separate them from their original microstate. This will be extremely helpful in Ember/React.

```jsx
let { increment } = create(Number, 42);

<button onclick={increment)>Click me</button>
```