### PR TITLE
Make sure value is taken from the microstate

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -105,6 +105,7 @@ export class Microstate {
   }
 
   static create(Type, value) {
+    value = value ? value.valueOf() : value;
     return flatMap(tree => {
       if (tree.Type.prototype.hasOwnProperty("initialize")) {
         let initialized = tree.microstate.initialize(tree.value);

--- a/tests/microstate.test.js
+++ b/tests/microstate.test.js
@@ -6,14 +6,31 @@ it('exports create', function() {
 });
 
 describe('create', () => {
-  it(`uses valueOf microstates instance that's passed to it`, () => {
-    class Person {
-      name = String;
-    }
-    let value = { name: "Taras" };
-    let m1 = create(Person, value);
-    expect(m1.valueOf()).toEqual(value);
+  class Person {
+    name = String;
+  }
+  let value = { name: "Homer" };
+  let homer;
+  beforeEach(() => {
+    homer = create(Person, value);
   });
+  it('uses valueOf microstates instance that\'s passed to it', () => {
+    expect(homer.valueOf()).toEqual(value);
+  });
+  describe('calling create with microstate', () => {
+    class AgingPerson {
+      name = String;
+      age = Number;
+    }
+    let homerWithAge;
+    beforeEach(() => {
+      homerWithAge = create(AgingPerson, homer);
+    });
+    it('has values for both composed types', () => {
+      expect(homerWithAge.name.state).toBe('Homer');
+      expect(homerWithAge.age.state).toBe(0);
+    });
+  })
 });
 
 describe('valueOf', () => {


### PR DESCRIPTION
This PR restores previous test and functionality that allowed a microstate to be passed as value to the create function. The create function will automatically call valueOf() on passed in value.