### PR TITLE
Add `created by frontside.io` badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/microstates/microstates.js/badge.svg?branch=master)](https://coveralls.io/github/microstates/microstates.js?branch=master)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Gitter](https://badges.gitter.im/microstates/microstates.js.svg)](https://gitter.im/microstates/microstates.js?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Created by The Frontside](https://img.shields.io/badge/created%20by-frontside.io-blue.svg)](https://frontside.io)
 
 # Microstates
 


### PR DESCRIPTION
This PR adds `created by frontside.io` badge to the README. It's a subtle way to show people who is behind the Microstates goodness.