### PR TITLE
Bring `from()` back from the dead.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,3 @@
 export { create } from './src/microstates';
 export { ArrayType, ObjectType } from './src/types';
+export { default as from } from './src/literal';

--- a/src/literal.js
+++ b/src/literal.js
@@ -1,0 +1,26 @@
+import { create } from './microstates';
+
+class Literal {
+  initialize(value) {
+    if (value == null) {
+      return this;
+    }
+    value = value.valueOf();
+    switch (typeof value) {
+    case "number":
+      return create(Number, value);
+    case "string":
+      return create(String, value);
+    case "boolean":
+      return create(Boolean, value);
+    default:
+      if (Array.isArray(value)) {
+        return create([Literal], value);
+      } else {
+        return create({Literal}, value);
+      }
+    }
+  }
+}
+
+export default (value) => create(Literal, value);

--- a/tests/literal.test.js
+++ b/tests/literal.test.js
@@ -1,0 +1,39 @@
+import expect from 'expect';
+import literal from '../src/literal';
+
+describe('Literal Syntax', function() {
+  it('can create numbers', function() {
+    expect(literal(5).increment().state).toEqual(6);
+  });
+  it('can create strings', function() {
+    expect(literal('hello').concat(' goodbye').state).toEqual('hello goodbye');
+  });
+  it('can create booleans', function() {
+    expect(literal(true).toggle().state).toEqual(false);
+  });
+  it('can create objects', function() {
+    expect(literal({}).put('hello', 'world').state).toEqual({hello: 'world'});
+  });
+  it('can create arrays', function() {
+    expect(literal([]).push('hello').push('world').state).toEqual(['hello', 'world']);
+  });
+  it('understands deeply nested objects and arrays', function() {
+    let ms = literal({array: [5, { bool: true }], string: "hi", object: {object: {}}})
+        .array[0].increment()
+        .array[1].bool.toggle()
+        .string.concat(" mom")
+        .object.put('another', 'property')
+        .object.object.put('deep', 'state');
+
+    expect(ms.state).toEqual({
+      array: [6, { bool: false }],
+      string: "hi mom",
+      object: {
+        another: 'property',
+        object: {
+          deep: 'state'
+        }
+      }
+    })
+  });
+});


### PR DESCRIPTION
The previous version of microstates had a `from` method wherein you could bring to life an entire microstate tree just by passing in a JavaScript object literal.

The type of the corresponding microstate tree is derived from the JavaScript literal at each point.

```js
import { from } from 'microstates';

let ms = from({array: [5, { bool: true }], string: "hi", object: {object: {}}})
    .array[0].increment()
    .array[1].bool.toggle()
    .string.concat(" mom")
    .object.put('another', 'property')
    .object.object.put('deep', 'state');

ms.state //>
 {
      array: [6, { bool: false }],
      string: "hi mom",
      object: {
        another: 'property',
        object: {
          deep: 'state'
        }
    }
```

To accomplish this, it just uses the initialization transition to determine which type the microstate should _actually_ be, and then creates it.