### PR TITLE
Release 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,33 @@
-# Change Log
+# Changelog
+All notable changes to this project will be documented in this file.
 
-## [0.8.1](https://github.com/microstates/microstates.js/compare/v0.8.0...v0.8.1)
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-- [CHORE] Bump to funcadelic 0.5.1 #139
+## [Unreleased]
 
-## [0.8.0](https://github.com/microstates/microstates.js/compare/v0.7.3...v0.8.0)
+## [0.9.1] - 2018-07-28
+### Changed
+- Migrate to the picostates architecture. This introduces many, many
+  breaking changes. See
+  https://github.com/microstates/microstates.js/pull/158 for details.
 
-- [BREAKING] Removed automatic caching of getters and memoize getters dependency #139
-- [BREAKING] exposed use for middleware and map for array mapping #138
-- [BREAKING] Fix transitions of parameterized arrays #127
-- [BREAKING] Drop UMD build and fix cjs/es builds #141
+## [0.8.1] - 2018-06-20
+### Changed
+- Bump to funcadelic 0.5.1 #139
 
+## [0.8.0] - 2018-06-29
+### Added
 - [ENHANCEMENT] Allow putting and assigning microstates to objects #119
 - [ENHANCEMENT] Added formatting to microstate types #133
 - [ENHANCEMENT] Add ability to include microstates in from #115
 - [ENCHANCEMENT] Transitions are now auto bound #142
 
+### Changed
+- [BREAKING] Removed automatic caching of getters and memoize getters dependency #139
+- [BREAKING] exposed use for middleware and map for array mapping #138
+- [BREAKING] Fix transitions of parameterized arrays #127
+- [BREAKING] Drop UMD build and fix cjs/es builds #141
 - [CHORE] Upgraded to funcadelic 0.5.0 #128
 - [CHORE] Added failing test for observable from arraylike #131
 - [CHORE] Removed momoize-getters dependency from package.json #140

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microstates",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Composable State Primitives for JavaScript",
   "keywords": [
     "lens",


### PR DESCRIPTION
Release the picostates architecture to the wild. Note that I didn't really understand how npm tags worked and so I though that you could release 0.9.0 on _both_ the `beta` _and_ the `latest`channels. This is not the case, and so there will be no public release of 0.9.0

This also updates the changeling format to be compatible with https://keepachangelog.com