### PR TITLE
Added map query to Reducible

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 export { create } from './src/microstates';
 export { ArrayType, ObjectType } from './src/types';
 export { default as from } from './src/literal';
-export { reduce, filter } from './src/query';
+export { map, filter, reduce } from './src/query';

--- a/src/query.js
+++ b/src/query.js
@@ -6,9 +6,13 @@ export const Reducible = type(class Reducible {
     return reduce(reducible, fn, initial);
   }
 
+  map(reducible, fn) {    
+    return reduce(reducible, (mapped, member) => mapped.concat(fn(member)), []);
+  }
+
   filter(reducible, predicate) {
     return reduce(reducible, (filtered, member) => predicate(member) ? filtered.concat(member) : filtered, []);
   }
 });
 
-export const { reduce, filter } = Reducible.prototype;
+export const { map, filter, reduce } = Reducible.prototype;

--- a/tests/examples/cart.test.js
+++ b/tests/examples/cart.test.js
@@ -2,7 +2,7 @@ import expect from 'expect';
 
 import { create } from '../../src/microstates';
 import { ArrayType } from '../../src/types';
-import { reduce } from '../../src/query';
+import { reduce, map } from '../../src/query';
 
 describe('cart example', () => {
   class Cart {
@@ -14,6 +14,10 @@ describe('cart example', () => {
 
     get count() {
       return reduce(this.products, (acc, product) => acc + product.state.quantity, 0);
+    }
+
+    get prices() {
+      return map(this.products, product => product.state.price);
     }
   }
   describe('adding products without initial value', () => {
@@ -34,6 +38,9 @@ describe('cart example', () => {
       expect(ms.state).toEqual({
         products: [{ quantity: 1, price: 10 }, { quantity: 2, price: 20 }],
       });
+    });
+    it('maps products', () => {
+      expect(ms.prices).toEqual([10, 20]);
     });
   });
 });

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -4,6 +4,7 @@ import * as exports from '../index';
 describe('package', () => {
   it('exports create', () => expect(exports.create).toBeDefined());
   it('exports from', () => expect(exports.from).toBeDefined());
+  it('exports map', () => expect(exports.map).toBeDefined());
   it('exports filter', () => expect(exports.filter).toBeDefined());
   it('exports reduce', () => expect(exports.reduce).toBeDefined());
   it('exports ArrayType', () => expect(exports.ArrayType).toBeDefined());

--- a/tests/query.test.js
+++ b/tests/query.test.js
@@ -1,6 +1,5 @@
 import expect from 'expect';
 import { create } from '../src/microstates';
-import ArrayType from '../src/types/array';
 
 import { TodoMVC } from './todomvc';
 


### PR DESCRIPTION
This PR makes it possible to use map operation in queries. It will create an array object with a function applied to each item. This should make it possible for us to map an array of microstates to React Components.

```jsx
import React from 'react';
import { map, create } from 'microstates';

let numbers = create([Number], [1, 2, 3]);

React.render(root, (
  <ul>
    {map(numbers, number => (
      <li>
       <button onClick={() => number.increment() })>Increment {number.state}</button>
     </li>
    ))}
  </ul>
));
```