### PR TITLE
Use JavaScript types instead of Microstates types in examples

### DIFF
--- a/tests/examples/authentication.test.js
+++ b/tests/examples/authentication.test.js
@@ -1,10 +1,8 @@
 import expect from 'expect';
 import { create } from '../../src/microstates';
 
-import { ObjectType, ArrayType, BooleanType, Any } from '../../src/types';
-
 class AnonymousSession {
-  content = create(Any);
+  content = create();
 
   initialize(session) {
     if (session) {
@@ -18,8 +16,8 @@ class AnonymousSession {
 }
 
 class AuthenticatedSession {
-  isAuthenticated = create(BooleanType, true);
-  content = create(ObjectType, {});
+  isAuthenticated = create(Boolean, true);
+  content = create(Object, {});
 
   logout() {
     return create(AnonymousSession);

--- a/tests/examples/cart.test.js
+++ b/tests/examples/cart.test.js
@@ -1,12 +1,11 @@
 import expect from 'expect';
 
 import { create } from '../../src/microstates';
-import { ArrayType } from '../../src/types';
 import { reduce } from '../../src/query';
 
 describe('cart example', () => {
   class Cart {
-    products = create(ArrayType);
+    products = create(Array);
 
     get price() {
       return reduce(this.products, (acc, product) => acc + product.state.quantity * product.state.price, 0);
@@ -16,6 +15,7 @@ describe('cart example', () => {
       return reduce(this.products, (acc, product) => acc + product.state.quantity, 0);
     }
   }
+
   describe('adding products without initial value', () => {
     let ms;
     beforeEach(() => {


### PR DESCRIPTION
This makes examples easier to understand because uses really should not know anything about our internal types.