### PR TITLE
Introduce a friendly repl.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- REPL for experimenting with, and demoing microstates.
 
 ## [0.9.2] - 2018-07-31
 ### Added

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "module": "dist/microstates.es.js",
   "repository": "git+ssh://git@github.com/microstates/microstates.js.git",
   "scripts": {
+    "start": "node repl.js",
     "test": "mocha --recursive -r tests/setup tests",
     "build": "rollup -c",
     "prepare": "npm run build",

--- a/repl.js
+++ b/repl.js
@@ -1,0 +1,48 @@
+let babel = require('@babel/core');
+let repl = require('repl')
+
+require('./tests/setup');
+
+// this code lifted from the @babel/node package
+// https://github.com/babel/babel/blob/master/packages/babel-node/src/_babel-node.js#L104-L117
+const _eval = function(code, filename) {
+  code = code.trim();
+  if (!code) return undefined;
+
+  code = babel.transform(code, {
+    filename: filename,
+  }).code;
+
+  return vm.runInThisContext(code, {
+    filename: filename,
+  });
+};
+
+
+// This code lifted from the @babel/node package
+// https://github.com/babel/babel/blob/master/packages/babel-node/src/_babel-node.js#L206-L221
+function replEval(code, context, filename, callback) {
+  let err;
+  let result;
+
+  try {
+    if (code[0] === "(" && code[code.length - 1] === ")") {
+      code = code.slice(1, -1); // remove "(" and ")"
+    }
+
+    result = _eval(code, filename);
+  } catch (e) {
+    err = e;
+  }
+
+  callback(err, result);
+}
+
+// put all of the microstate functions into the global scope
+Object.assign(global, require('./index'))
+
+//start the repl using the @babel/node
+repl.start({
+  eval: replEval,
+  useGlobal: true,
+});

--- a/src/identity.js
+++ b/src/identity.js
@@ -80,7 +80,10 @@ export default function Identity(microstate, observe = x => x) {
     constructor(value, path) {
       super();
       this.state = value;
-      this[info] = path;
+      Object.defineProperty(this, info, {
+        configurable: true,
+        value: path
+      });
     }
 
   })

--- a/src/microstates.js
+++ b/src/microstates.js
@@ -130,7 +130,10 @@ export class Meta {
       return object;
     } else {
       let clone = Semigroup.for(Object).append(object, {});
-      clone[Meta.LOOKUP] = meta;
+      Object.defineProperty(clone, Meta.LOOKUP, {
+        configurable: true,
+        value: meta
+      });
       return clone;
     }
   })

--- a/src/types/array.js
+++ b/src/types/array.js
@@ -6,6 +6,10 @@ import { Filterable } from 'funcadelic';
 import parameterized from '../parameterized';
 
 export default parameterized(T => class ArrayType {
+  static get name() {
+    return `Array<${T.name}>`;
+  }
+
   push(value) {
     return [...this.state, value];
   }

--- a/src/types/boolean.js
+++ b/src/types/boolean.js
@@ -1,4 +1,6 @@
 export default class BooleanType {
+  static name = "Boolean";
+
   initialize(value) {
     return !!value;
   }

--- a/src/types/number.js
+++ b/src/types/number.js
@@ -1,4 +1,6 @@
 export default class NumberType {
+  static name = "Number";
+
   initialize(value) {
     if (value == null) {
       return 0;

--- a/src/types/object.js
+++ b/src/types/object.js
@@ -7,6 +7,10 @@ import parameterized from '../parameterized'
 export default parameterized(T => class ObjectType {
   static T = T;
 
+  static get name() {
+    return `Object<${T.name}>`;
+  }
+
   static initialize() {
     Assemble.instance(ObjectType, {
       assemble(Type, microstate, value) {

--- a/src/types/string.js
+++ b/src/types/string.js
@@ -1,4 +1,6 @@
 export default class StringType {
+  static name = "String";
+
   initialize(value) {
     return String(value == null ? '' : value);
   }


### PR DESCRIPTION
When experimenting with, or demonstrating microstates, it helps to have "live" microstates environment to work with. We've been using runkit or codesandbox, but they each have their drawbacks, not least of which is that they don't work without internet connectivity.

This introduces a repl script which boots a node.js repl server containing all of the microstate functions attached to the global namespace.

You can invoke it by running

```
$ yarn start
```

![2018-07-31 14 36 42](https://user-images.githubusercontent.com/4205/43485804-71bc9eda-94cf-11e8-8599-fb7e21b62d9f.gif)


Some fixups were made to the class naming so that it is more easily
digestible:

1. Primitive types are just called primitive types now:
`Microstate<NumberType>` -> `Microstate<Number>`;
2. The `meta` property attached to each Microstate is now
non-enumerable, so that it doesn't show up in console.logs by default.
3. The `info` property of the `Id` type is now non-enumerable.

Before:

```
> create(class Person { name = String; occupation = String }, { name: 'Charles', occupation: 'Developer'});
Microstate<Person> {
  name:
   Microstate<StringType> {
     state: 'Charles',
     [Symbol(Meta)]:
      Meta {
        path: [Array],
        source: [Microstate<StringType>],
        context: [Getter] } },
  occupation:
   Microstate<StringType> {
     state: 'Developer',
     [Symbol(Meta)]:
      Meta {
        path: [Array],
        source: [Microstate<StringType>],
        context: [Getter] } },
  state: { name: 'Charles', occupation: 'Developer' },
  [Symbol(Meta)]: Meta { path: [], context: [Getter] } }
```

After:
```
> create(class Person { name = String; occupation = String }, { name: 'Charles', occupation: 'Developer'});
Microstate<Person> {
  name: Microstate<String> { state: 'Charles' },
  occupation: Microstate<String> { state: 'Developer' },
  state: { name: 'Charles', occupation: 'Developer' } }
```

### Todos, Followups.

In two cases, we use `defineProperty` instead of a simple `=` assignment in order to make the symbol properties non-enumerable.  I don't know if this has any performance implications.