### PR TITLE
Remove ArrayType and ObjectType exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
 export { create } from './src/microstates';
-export { ArrayType, ObjectType } from './src/types';
 export { default as from } from './src/literal';
 export { map, filter, reduce } from './src/query';

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -7,6 +7,4 @@ describe('package', () => {
   it('exports map', () => expect(exports.map).toBeDefined());
   it('exports filter', () => expect(exports.filter).toBeDefined());
   it('exports reduce', () => expect(exports.reduce).toBeDefined());
-  it('exports ArrayType', () => expect(exports.ArrayType).toBeDefined());
-  it('exports ObjectType', () => expect(exports.ObjectType).toBeDefined());
 });

--- a/tests/parameterized.test.js
+++ b/tests/parameterized.test.js
@@ -96,7 +96,7 @@ describe("Parameterized Microstates: ", () => {
         description = String;
       };
       TodoList = class TodoList {
-        items = ArrayType.of(Item);
+        items = [Item];
       };
       m = create(TodoList, {
         items: [
@@ -118,7 +118,7 @@ describe("Parameterized Microstates: ", () => {
   describe("with simple parameters", function() {
     let m, value;
     beforeEach(function() {
-      let PriceList = ObjectType.of(ArrayType.of(Number));
+      let PriceList = create({}).constructor.Type.of([Number]);
       value = {
         oranges: [50, 20],
         apples: [1, 2, 45]


### PR DESCRIPTION
We want to keep the API surface as small as possible for the moment.