### PR TITLE
Always use a context-free microstate when lens setting.

### DIFF
--- a/src/microstates.js
+++ b/src/microstates.js
@@ -41,7 +41,7 @@ const toPicoType = stable(function toPicoType(Type) {
         microstate = create(this.constructor, value);
       }
       let meta = Meta.get(this);
-      return set(meta.lens, microstate, meta.context);
+      return set(meta.lens, Meta.source(microstate), meta.context);
     }
 
     [SymbolObservable]() { return this['@@observable'](); }

--- a/tests/microstates.test.js
+++ b/tests/microstates.test.js
@@ -74,6 +74,35 @@ describe("Microstates", () => {
           expect(next.any.state).toBe('ohai boss');
         });
       });
+
+      describe('setting the nested object to the same value', function() {
+        let next;
+
+        beforeEach(function() {
+          next = something.any.set(5).any.set(5).any.set(5)
+        });
+
+        it('maintains its shape', function() {
+          expect(next.state).toEqual({any: 5});
+        });
+
+        it('preserves its === equivalence', function() {
+          expect(next.any.set(5).any.set(5)).toBe(next);
+        });
+      });
+
+      describe('setting a microstate to another microstate from another tree', function() {
+        let next
+        beforeEach(function() {
+          something = create(Something, {any: "hi"});
+          next = create().set(something.any).set("hi").set("hi");
+        });
+        it('does not get confused', function() {
+          expect(next.state).toEqual("hi")
+        });
+      });
+
+
     });
   });
 
@@ -130,9 +159,4 @@ describe("Microstates", () => {
       });
     });
   });
-
 })
-
-function context(object) {
-  return Meta.get(object).context
-}


### PR DESCRIPTION
The `microstate.set()` method ultimately is responsible for producing a new microstate and then embedding it into the same location using the implicit lens. This microstate that gets passed to the lens must be "context-free" or sitting at the head of its own tree.

There is an optimization however to cover the case where the value being passed in is the same as the current microstate's state. In thatevent, we were attempting to re-use the current microstate. However, what we actually wanted was to return the _decontextualized_ version of the current microstate.

This change makes sure to always use the decontextualized microstate
before setting it with the lens.

As a bonus, this means that you can now "pass" microstates from one tree to another and it will work just fine.

```js
class A {
  b = class B {
    c = class C {
      value = Number;
    }
  }
}

let a1 = create(A, {b: {c: { value: 42 }}})
let a2 = create(A);

a2.b.c.set(a1.b.c); //no problem!

a2.b.c.value.state; //=> 42
```