### PR TITLE
Workaround non-deterministic order for registering syntactic sugar

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,11 @@
+/** HOTFIX
+* workaround for https://github.com/microstates/microstates.js/issues/186
+* this lines should not be necessary because syntactic sugar precedence should be
+* deterministic.
+*/
+import "./src/types";
+/** END HOTFIX */
+
 export { create } from './src/microstates';
 export { default as from } from './src/literal';
 export { map, filter, reduce } from './src/query';


### PR DESCRIPTION
Because the list of syntax sugar is mutable and is appended to from different portions of the codebase, some sugars will not be registered in the right order.

This isn't a long-term fix for the issue, but it does resolve it in the short term.