### PR TITLE
Make redundant transitions fully idemptotent for Identities.

### DIFF
--- a/src/identity.js
+++ b/src/identity.js
@@ -51,7 +51,8 @@ export default function Identity(microstate, observe = x => x) {
           let path = this[info];
           let microstate = view(Path(path), current);
           let next = microstate[name](...args);
-          return tick(next);
+
+          return next === current ? identity : tick(next);
         }
         return methods;
       }, {}, methods));

--- a/tests/identity.test.js
+++ b/tests/identity.test.js
@@ -46,6 +46,26 @@ describe('Identity', () => {
     });
   });
 
+  describe('idempotency', function() {
+    let calls;
+    let store;
+    let next;
+    beforeEach(function() {
+      calls = 0;
+      store = Identity(microstate, x => {
+        calls++;
+        return x;
+      });
+      next = store.todos[0].completed.set(true);
+    });
+
+    it('returns the same id in the event that the state is the same', function() {
+      expect(next).toBe(store);
+    });
+    it('does not invoke the idenity function after the initial invocation', function() {
+      expect(calls).toEqual(1);
+    });
+  });
   describe('identity of queries', function() {
 
     it('traverses queries and includes the microstates within them', function() {


### PR DESCRIPTION
When you have a Microstate:

```js
class Type {
  string = create(String, 'hi');
}

let type = create(Type);
```

Then it doesn't matter how often you set a value it contains to be the same value it was, you always get the same object back.

```js

type.string.set('hi').string.concat('').string.set('hi') === type
//=> true
```

The same is true for identity stores. No matter how many times you change them, if you transition them to the same state, they return the same object. However, they were still emitting events for these 'no-oop' transitions.

This adds a check to just avoid an update if the transition does not change the current microstate in any way.