### PR TITLE
Implicitly bind methods for microstates inside a store.

### DIFF
--- a/src/bind-methods.js
+++ b/src/bind-methods.js
@@ -1,0 +1,29 @@
+import { filter, map } from 'funcadelic'
+
+export default function bindMethods(Type) {
+  var descriptors = Object.getOwnPropertyDescriptors(Type.prototype);
+
+  let methodDescriptors = filter(({ key: name, value: desc }) => {
+    return name !== 'constructor' && typeof desc.value === 'function';
+  }, descriptors);
+
+  let boundMethodDescriptors = map((desc, name) => {
+    return {
+      configurable: true,
+      enumerable: false,
+      get() {
+        Object.defineProperty(this, name, {
+          enumerable: false,
+          value: (...args) => {
+            return desc.value.apply(this, args);
+          }
+        })
+        return this[name];
+      }
+    }
+  }, methodDescriptors);
+
+  Object.defineProperties(Type.prototype, boundMethodDescriptors);
+
+  return Type;
+}

--- a/src/identity.js
+++ b/src/identity.js
@@ -3,6 +3,7 @@ import { Meta } from './microstates';
 import { treemap } from './tree';
 import parameterized from './parameterized';
 import { Hash, equals } from './hash';
+import bindMethods from './bind-methods';
 
 //function composition should probably not be part of lens :)
 import { compose, view, Path } from './lens';
@@ -57,6 +58,8 @@ export default function Identity(microstate, observe = x => x) {
         return methods;
       }, {}, methods));
 
+
+      bindMethods(this);
 
       Object.keys(descriptors).forEach(propertyName => {
         let desc = descriptors[propertyName];

--- a/tests/bind-methods.test.js
+++ b/tests/bind-methods.test.js
@@ -1,0 +1,23 @@
+import expect from 'expect';
+
+import bindMethods from '../src/bind-methods';
+
+describe('invoking bound methods', function() {
+  let Type;
+  let instance;
+  let method;
+  beforeEach(function() {
+    Type = bindMethods(class {
+      someMethod() {
+        return this.invocant = this;
+      }
+    })
+    instance = new Type();
+    method = instance.someMethod;
+    method();
+  });
+
+  it('enables invoking an instance method even though the function is unbound.', function() {
+    expect(instance.invocant).toBe(instance);
+  });
+});

--- a/tests/identity.test.js
+++ b/tests/identity.test.js
@@ -46,6 +46,25 @@ describe('Identity', () => {
     });
   });
 
+  describe('implicit method binding', function() {
+    let next;
+    beforeEach(function() {
+      let shift = id.todos.shift;
+      next = shift();
+    });
+    it('still completes the transition', function() {
+      expect(next.state).toEqual({
+        todos: [{
+          title: "Convince People Microstates is awesome", completed: false
+        }, {
+          title: "Take out the Trash", completed: false
+        }, {
+          title: "profit $$", completed: false
+        }]
+      })
+    });
+  });
+
   describe('idempotency', function() {
     let calls;
     let store;


### PR DESCRIPTION
When making a user interface, you often need to pass the call back as an atomic function. For example, in React you would say:

```jsx
<MyComponent onClick={() => counter.increment() }></MyComponent>
```

With this change, the function property of every microstate is implicitly bound to that microstate so that the following code can be written as:

```jsx
<MyComponent onClick={counter.increment}></MyComponent>
```

resolves #176 

### Open Questions:

- We should probably clean up and unify all of the muckery that happens on prototypes just to cut down the complexity and code-size.
- By doing this, we're making stack traces a little more weird.
- Should we also make implicitly bound transitions on the raw microstates.