### PR TITLE
Add benchmarks to set bar for performance improvements.

### DIFF
--- a/benchmarks/any.benchmark.js
+++ b/benchmarks/any.benchmark.js
@@ -1,0 +1,23 @@
+import { create, Store } from '../index';
+import benchmark from './benchmark';
+
+export default benchmark('Any', function AnyBenchmarks(suite) {
+  suite.add('create(Any)', () => {
+    create();
+  });
+  suite.add('create(Any, 5)', () => {
+    create(undefined, 5);
+  });
+  suite.add('create(Any).set(5)', () => {
+    create().set(5);
+  })
+  suite.add('Store(create(Any))', () => {
+    Store(create());
+  });
+  suite.add('Store(create(Any, 5))', () => {
+    Store(create(undefined, 5));
+  });
+  suite.add('Store(create().set(5))', () => {
+    Store(create().set(5));
+  })
+});

--- a/benchmarks/array.benchmark.js
+++ b/benchmarks/array.benchmark.js
@@ -1,0 +1,26 @@
+import { Store, create } from '../index';
+import benchmark from './benchmark';
+
+const BIGARRAY = Array(100);
+BIGARRAY.fill(0);
+
+export default benchmark('Array', function(suite) {
+  suite.add('create([])', () => {
+    create([]);
+  })
+  suite.add('create([], Array(100))', () => {
+    create([], BIGARRAY);
+  })
+  suite.add('create([]).set(Array(100))', () => {
+    create([]).set(BIGARRAY);
+  })
+  suite.add('Store(create([]))', () => {
+    Store(create([]));
+  })
+  suite.add('Store(create([], Array(100)))', () => {
+    Store(create([], BIGARRAY));
+  })
+  suite.add('Store(create([]).set(Array(100)))', () => {
+    Store(create([])).set(BIGARRAY);
+  })
+});

--- a/benchmarks/benchmark.js
+++ b/benchmarks/benchmark.js
@@ -1,0 +1,12 @@
+export default function(name, definition) {
+  return function(suite) {
+    return definition({
+      add(desc, operation) {
+        return suite.add(desc, function() {
+          this.suiteName = name;
+          return operation();
+        });
+      }
+    })
+  }
+}

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -1,0 +1,48 @@
+
+import any from './any.benchmark'
+import number from './number.benchmark';
+import array from './array.benchmark';
+import object from './object.benchmark';
+
+import Benchmark from 'benchmark';
+import Table from 'cli-table';
+
+const ENA = 'Err! N/A';
+
+const suite = new Benchmark.Suite({
+
+  onComplete() {
+    let table = new Table({
+      head: ['Suite', 'Benchmark', 'ops/sec', 'σ', 'sample size']
+    })
+    for (let i = 0; i < this.length; i++) {
+      let benchmark = this[i];
+      let { stats } = benchmark;
+      if (benchmark.error) {
+        table.push([String(benchmark.suiteName), benchmark.name, ENA, ENA, stats.sample.length ]);
+      } else {
+        let { hz } = benchmark;
+        let ops = Benchmark.formatNumber(hz.toFixed(hz < 100 ? 2 : 0))
+        let sigma = `± ${stats.rme.toFixed(2)} %`;
+        table.push([String(benchmark.suiteName), benchmark.name, ops, sigma, stats.sample.length])
+      }
+    }
+    console.log(String(table));
+  },
+  onCycle(event) {
+    if (!event.target.error) {
+      console.log(String(event.target));
+    }
+  },
+  onError(event) {
+    let { error } = event.target;
+    console.log(String(event.target), error);
+  }
+});
+
+any(suite);
+number(suite);
+array(suite);
+object(suite);
+
+suite.run({ async: true });

--- a/benchmarks/number.benchmark.js
+++ b/benchmarks/number.benchmark.js
@@ -1,0 +1,24 @@
+import { Store, create } from '../index';
+import benchmark from './benchmark';
+
+export default benchmark('Number', function(suite) {
+  suite.add('create(Number)', () => {
+    create(Number);
+  })
+  suite.add('create(Number, 42)', () => {
+    create(Number, 42);
+  })
+  suite.add('create(Number).set(42)', () => {
+    create(Number).set(42);
+  })
+  suite.add('Store(create(Number))', () => {
+    Store(create(Number));
+  })
+  suite.add('Store(create(Number, 42))', () => {
+    Store(create(Number, 42));
+  })
+
+  suite.add('Store(create(Number)).set(42)', () => {
+    Store(create(Number)).set(42);
+  })
+})

--- a/benchmarks/object.benchmark.js
+++ b/benchmarks/object.benchmark.js
@@ -1,0 +1,32 @@
+import { Store, create } from '../index';
+import benchmark from './benchmark';
+
+const BIGOBJECT = {};
+for (let i = 0; i < 100; i++) {
+  BIGOBJECT[`key-${i}`] = `value-${i}`;
+}
+
+
+export default benchmark('Object', function(suite) {
+  suite.add('create({})', () => {
+    create({});
+  })
+  suite.add('create({}).set({})', () => {
+    create({}).set({});
+  })
+  suite.add('create({}, BIGOBJECT)', () => {
+    create({}, BIGOBJECT);
+  })
+  suite.add('create({}).set(BIGOBJECT)', () => {
+    create({}).set(BIGOBJECT);
+  })
+  suite.add('Store(create({}))', () => {
+    Store(create({}));
+  })
+  suite.add('Store(create({}, BIGOBJECT))', () => {
+    Store(create({}, BIGOBJECT));
+  })
+  suite.add('Store(create({}).set(BIGOBJECT))', () => {
+    Store(create({})).set(BIGOBJECT);
+  })
+});

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "start": "node repl.js",
     "test": "mocha --recursive -r tests/setup tests",
     "build": "rollup -c",
+    "bench": "node -r ./tests/setup benchmarks/index.js",
     "prepare": "npm run build",
     "prerelease": "npm test && npm run build"
   },
@@ -36,6 +37,8 @@
     "@babel/plugin-proposal-class-properties": "7.0.0-beta.54",
     "@babel/preset-env": "^7.0.0-beta.54",
     "@babel/register": "^7.0.0-beta.54",
+    "benchmark": "^2.1.4",
+    "cli-table": "^0.3.1",
     "expect": "^23.4.0",
     "mocha": "^5.2.0",
     "object.getownpropertydescriptors": "^2.0.3",


### PR DESCRIPTION
We're seeing some pretty atrocious performance charateristics on certain microstates, and so we need a way to frame the problem, point at it, and also be able to measure what success would look like in the event that we fix it.

This adds a benchmark suite to microstates that can be invoked with

```
yarn bench
```

![image](https://user-images.githubusercontent.com/4205/43997072-0b2e29ca-9d87-11e8-9647-6b99d17e0477.jpeg)


It outputs its data in tabular form, but it would be awesome if we could track the output over time and only accept pull requests that don't downgrade performance by a significant margin.