### PR TITLE
Allow "collection" microstates to control how objects are added and removed from them

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 export { create } from './src/microstates';
 export { default as from } from './src/literal';
-export { map, filter, reduce } from './src/query';
+export { map, filter, reduce, first, second, third, at, last } from './src/query';
 export { default as Store } from './src/identity';

--- a/src/query.js
+++ b/src/query.js
@@ -6,12 +6,30 @@ export const Reducible = type(class Reducible {
     return reduce(reducible, fn, initial);
   }
 
-  map(reducible, fn) {    
+  map(reducible, fn) {
     return reduce(reducible, (mapped, member) => mapped.concat(fn(member)), []);
   }
 
   filter(reducible, predicate) {
     return reduce(reducible, (filtered, member) => predicate(member) ? filtered.concat(member) : filtered, []);
+  }
+
+  // stubs for array access
+  first(array) {
+    return at(array, 0);
+  }
+
+  second(array) {
+    return at(array, 1);
+  }
+  third(array) {
+    return at(array, 2);
+  }
+  at(array, index) {
+    return array[index];
+  }
+  last(array) {
+    return at(array, array.length - 1);
   }
 });
 
@@ -21,4 +39,4 @@ Reducible.instance(Array, {
   }
 });
 
-export const { map, filter, reduce } = Reducible.prototype;
+export const { map, filter, reduce, first, second, third, at, last } = Reducible.prototype;

--- a/tests/identity.test.js
+++ b/tests/identity.test.js
@@ -2,7 +2,7 @@ import expect from 'expect';
 
 import Identity from '../src/identity';
 import { create } from '../src/microstates';
-
+import { first, second, third, at } from '../index';
 import { TodoMVC, Todo } from './todomvc';
 
 describe('Identity', () => {
@@ -24,8 +24,8 @@ describe('Identity', () => {
   it('has the same shape as the initial state.', function() {
     expect(id.completeAll).toBeInstanceOf(Function);
     expect(id.todos.state.length).toBe(4);
-    expect(id.todos[0]).toBeInstanceOf(Todo);
-    expect(id.todos[0].state).toBe(microstate.todos[0].state)
+    expect(first(id.todos)).toBeInstanceOf(Todo);
+    expect(first(id.todos).state).toBe(first(microstate.todos).state)
   });
 
   describe('invoking a transition', function() {
@@ -36,13 +36,13 @@ describe('Identity', () => {
     it('transitions the nodes which did change', function() {
       expect(next).not.toBe(id);
       expect(next.todos).not.toBe(id.todos);
-      expect(next.todos[2]).not.toBe(id.todos[2]);
+      expect(third(next.todos)).not.toBe(third(id.todos));
     });
     it('maintains the === identity of the nodes which did not change', function() {
-      expect(next.todos[2].title).toBe(id.todos[2].title);
-      expect(next.todos[0]).toBe(id.todos[0]);
-      expect(next.todos[1]).toBe(id.todos[1]);
-      expect(next.todos[3]).toBe(id.todos[3]);
+      expect(third(next.todos).title).toBe(third(id.todos).title);
+      expect(first(next.todos)).toBe(first(id.todos));
+      expect(second(next.todos)).toBe(second(id.todos));
+      expect(at(next.todos, 3)).toBe(at(id.todos, 3));
     });
   });
 

--- a/tests/observable.test.js
+++ b/tests/observable.test.js
@@ -1,5 +1,6 @@
 import expect from 'expect';
 import { create } from "../src/microstates";
+import { first } from '../index';
 import ArrayType from "../src/types/array";
 import SymbolObservable from 'symbol-observable';
 import { from } from 'rxjs';
@@ -162,7 +163,7 @@ describe('array as root', () => {
 
   it('has array with one element', () => {
     expect(list.state.length).toBe(1);
-    expect(list[0].state.hello).toBeDefined();
+    expect(first(list).state.hello).toBeDefined();
   });
 
   describe('created observable', () => {
@@ -181,7 +182,7 @@ describe('array as root', () => {
 
     it('has array with one element', () => {
       expect(last.state.length).toBe(1);
-      expect(last[0].state.hello).toBeDefined();
+      expect(first(last).state.hello).toBeDefined();
     });
   });
 

--- a/tests/parameterized.test.js
+++ b/tests/parameterized.test.js
@@ -1,6 +1,7 @@
 import expect from 'expect';
 
-import { create }  from "../index";
+import { create, first, second }  from "../index";
+
 describe("Parameterized Microstates: ", () => {
   describe("sugar", function() {
     class Item {
@@ -14,7 +15,7 @@ describe("Parameterized Microstates: ", () => {
     describe("root [Item] to parameterized(Array)", function() {
       let m;
       beforeEach(function() {
-        m = create([Item], [{ isCompleted: false }])[0].isCompleted.toggle();
+        m = first(create([Item], [{ isCompleted: false }])).isCompleted.toggle();
       });
       it("runs transitions on sub items", function() {
         expect(m.state[0].isCompleted).toBe(true);
@@ -45,12 +46,12 @@ describe("Parameterized Microstates: ", () => {
     describe("composed [Item] to parameterized(Array)", function() {
       let m;
       beforeEach(function() {
-        m = create(TodoList, {
+        m = first(create(TodoList, {
           items: [{ isCompleted: false }]
-        }).items[0].isCompleted.toggle();
+        }).items).isCompleted.toggle();
       });
       it("runs transitions on sub items", function() {
-        expect(m.state.items[0].isCompleted).toBe(true);
+        expect(first(m.state.items).isCompleted).toBe(true);
       });
     });
 
@@ -65,7 +66,7 @@ describe("Parameterized Microstates: ", () => {
       let transitioned;
       beforeEach(function() {
         m = create(Counters, value);
-        transitioned = m.apples[0].increment().oranges[1].increment();
+        transitioned = second(first(m.apples).increment().oranges).increment();
       });
       it("uses the same value for state as the value ", function() {
         expect(m.state).toEqual(value);
@@ -96,8 +97,8 @@ describe("Parameterized Microstates: ", () => {
       });
       it("still respects transitions", function() {
         expect(
-          m.inventory.apples[0].increment()
-            .inventory.oranges[1].increment().state
+          second(first(m.inventory.apples).increment()
+            .inventory.oranges).increment().state
         ).toEqual({
           inventory: {
             oranges: [50, 21],
@@ -118,19 +119,19 @@ describe("Parameterized Microstates: ", () => {
       TodoList = class TodoList {
         items = [Item];
       };
-      m = create(TodoList, {
+      m = first(create(TodoList, {
         items: [
           { isCompleted: false, description: "Get Milk" },
           { isCompleted: false, description: "Feed Dog" }
         ]
-      }).items[0].isCompleted.toggle();
+      }).items).isCompleted.toggle();
     });
     it("runs transitions on sub items", function() {
       expect(m).toBeInstanceOf(TodoList);
       expect(m.state.items).toBeInstanceOf(Array);
       expect(m.state.items.length).toBe(2);
       expect(m.state.items[0].isCompleted).toBe(true);
-      expect(m.items[0]).toBeInstanceOf(Item);
+      expect(first(m.items)).toBeInstanceOf(Item);
       expect(m.state.items[1].isCompleted).toBe(false);
     });
   });
@@ -150,7 +151,7 @@ describe("Parameterized Microstates: ", () => {
     });
 
     it("still respects transitions", function() {
-      expect(m.apples[0].increment().oranges[1].increment().state).toEqual({
+      expect(second(first(m.apples).increment().oranges).increment().state).toEqual({
         oranges: [50, 21],
         apples: [2, 2, 45]
       });

--- a/tests/query.test.js
+++ b/tests/query.test.js
@@ -1,36 +1,35 @@
 import expect from 'expect';
 import { create } from '../src/microstates';
-import { map, filter, reduce } from '..';
-
+import { map, filter, reduce, first, second, third, at } from '../index';
 import { TodoMVC } from './todomvc';
 
 describe('A Microstate with queries', function() {
   let todomvc
   beforeEach(function() {
-    todomvc = create(TodoMVC)
-      .todos.push({title: "Take out The Milk"})
-      .todos.push({title: "Convince People Microstates is awesome"})
-      .todos.push({title: "Take out the Trash"})
-      .todos.push({title: "profit $$"})
-      .todos[0].toggle()
-      .todos[2].toggle()
+    todomvc = third(first(create(TodoMVC)
+                    .todos.push({title: "Take out The Milk"})
+                    .todos.push({title: "Convince People Microstates is awesome"})
+                    .todos.push({title: "Take out the Trash"})
+                    .todos.push({title: "profit $$"})
+                    .todos).toggle()
+                    .todos).toggle()
   });
   it('can partition an array microstate using filter', function() {
     expect(todomvc.completed.length).toEqual(2)
-    expect(todomvc.completed[0]).toEqual(todomvc.todos[0])
-    expect(todomvc.completed[1]).toEqual(todomvc.todos[2])
+    expect(first(todomvc.completed)).toEqual(first(todomvc.todos))
+    expect(second(todomvc.completed)).toEqual(third(todomvc.todos))
     expect(todomvc.active.length).toEqual(2)
-    expect(todomvc.active[0]).toEqual(todomvc.todos[1])
-    expect(todomvc.active[1]).toEqual(todomvc.todos[3])
+    expect(first(todomvc.active)).toEqual(second(todomvc.todos))
+    expect(second(todomvc.active)).toEqual(at(todomvc.todos, 3))
   });
 
   describe('invoking a transition from one of the object returned by a query.', function() {
     let next;
     beforeEach(function() {
-      next = todomvc.active[0].toggle()
+      next = first(todomvc.active).toggle()
     });
     it('has the desired effect on the original item', function() {
-      expect(next.todos[1].completed.state).toEqual(true);
+      expect(second(next.todos).completed.state).toEqual(true);
       expect(next.active.length).toEqual(1)
       expect(next.completed.length).toEqual(3)
     });

--- a/tests/type-shifting.test.js
+++ b/tests/type-shifting.test.js
@@ -1,5 +1,5 @@
 import expect from 'expect';
-import { create } from "../index";
+import { create, first, second, third } from "../index";
 
 describe("type-shifting", () => {
   class Shape {
@@ -92,9 +92,9 @@ describe("type-shifting", () => {
         shapes = [Shape];
       }
       let drawing = create(Drawing, { shapes: [{ a: 10 }, { a: 20, b: 30 }, { a: 100, b: 200, c: 300 }] });
-      expect(drawing.shapes[0]).toBeInstanceOf(Line);
-      expect(drawing.shapes[1]).toBeInstanceOf(Angle);
-      expect(drawing.shapes[2]).toBeInstanceOf(Triangle);
+      expect(first(drawing.shapes)).toBeInstanceOf(Line);
+      expect(second(drawing.shapes)).toBeInstanceOf(Angle);
+      expect(third(drawing.shapes)).toBeInstanceOf(Triangle);
     });
 
     describe("can type-shift into a parameterized type", () => {
@@ -110,7 +110,7 @@ describe("type-shifting", () => {
       it("can initialize into a parameterized array", () => {
         let array = Container.create(["a", "b", "c"]);
         expect(array.state).toMatchObject(["a", "b", "c"]);
-        expect(array[0].concat).toBeInstanceOf(Function);
+        expect(first(array).concat).toBeInstanceOf(Function);
       });
       it("can initialize into a parameterized object", () => {
         let object = Container.create({ a: "A", b: "B", c: "C" });
@@ -331,7 +331,7 @@ describe("type-shifting from create to parameterized array", () => {
     expect(group.state).toMatchObject({
       members: [{ name: "Taras" }, { name: "Charles" }, { name: "Siva" }],
     });
-    expect(group.members[0]).toBeInstanceOf(Person);
+    expect(first(group.members)).toBeInstanceOf(Person);
   });
 
   describe("transitioning shifted value", () => {

--- a/tests/types/array.test.js
+++ b/tests/types/array.test.js
@@ -2,6 +2,7 @@ import expect from 'expect';
 
 import ArrayType from '../../src/types/array';
 import { create } from '../../src/microstates';
+import { first, second, third, at } from '../../index';
 
 describe("ArrayType", function() {
   describe("when unparameterized", function() {
@@ -108,17 +109,17 @@ describe("ArrayType", function() {
         });
 
         it("has the new record", () => {
-          expect(pushed.records[0]).toBeInstanceOf(Record);
+          expect(first(pushed.records)).toBeInstanceOf(Record);
         });
 
         it("has given value", () => {
-          expect(pushed.state.records[0].content).toBe("Hi!");
+          expect(first(pushed.state.records).content).toBe("Hi!");
         });
 
         describe("changing record", () => {
           let changed;
           beforeEach(() => {
-            changed = pushed.records[0].content.set("Hello!");
+            changed = first(pushed.records).content.set("Hello!");
           });
 
           it("has changed value", () => {
@@ -156,7 +157,7 @@ describe("ArrayType", function() {
         });
 
         it("has the new record", () => {
-          expect(pushed.records[3]).toBeInstanceOf(Record);
+          expect(at(pushed.records, 3)).toBeInstanceOf(Record);
         });
 
         it("has given value", () => {
@@ -166,7 +167,7 @@ describe("ArrayType", function() {
         describe("changing record", () => {
           let changed;
           beforeEach(() => {
-            changed = pushed.records[3].content.set("Hello!");
+            changed = at(pushed.records, 3).content.set("Hello!");
           });
 
           it("has changed value", () => {
@@ -182,7 +183,7 @@ describe("ArrayType", function() {
         });
 
         it('removed last element from the array', () => {
-          expect(popped.records[2]).toBe(undefined);
+          expect(third(popped.records, 2)).toBe(undefined);
         });
 
         it('changed length', () => {
@@ -192,11 +193,11 @@ describe("ArrayType", function() {
         describe('changing record', () => {
           let changed;
           beforeEach(() => {
-            changed = popped.records[1].content.concat('!!!');
+            changed = second(popped.records).content.concat('!!!');
           });
 
           it('changed the content', () => {
-            expect(changed.records[1].content.state).toBe('Sweet!!!');
+            expect(second(changed.records).content.state).toBe('Sweet!!!');
           });
         });
       });
@@ -208,7 +209,7 @@ describe("ArrayType", function() {
         });
 
         it('removed first element from the array', () => {
-          expect(shifted.records[0].content.state).toBe('Sweet');
+          expect(first(shifted.records).content.state).toBe('Sweet');
         });
 
         it('changed length', () => {
@@ -218,11 +219,11 @@ describe("ArrayType", function() {
         describe('changing record', () => {
           let changed;
           beforeEach(() => {
-            changed = shifted.records[1].content.concat('!!!');
+            changed = second(shifted.records).content.concat('!!!');
           });
 
           it('changed the content', () => {
-            expect(changed.records[1].content.state).toBe('Woooo!!!');
+            expect(second(changed.records).content.state).toBe('Woooo!!!');
           });
         });
       });
@@ -233,29 +234,29 @@ describe("ArrayType", function() {
           unshifted = dataset.records.unshift({ content: "Hi!" });
         });
         it('pushed record to the beginning of the array', () => {
-          expect(unshifted.records[0].content.state).toBe('Hi!');
+          expect(first(unshifted.records).content.state).toBe('Hi!');
         });
         it('moved first record to second position', () => {
-          expect(unshifted.records[1].content.state).toBe('Herro');
+          expect(second(unshifted.records).content.state).toBe('Herro');
         });
 
         describe('change new record', () => {
           let changed;
           beforeEach(() => {
-            changed = unshifted.records[0].content.concat('!!!');
+            changed = first(unshifted.records).content.concat('!!!');
           });
           it('changed new record', () => {
-            expect(changed.records[0].content.state).toBe('Hi!!!!');
+            expect(first(changed.records).content.state).toBe('Hi!!!!');
           });
         });
 
         describe('change existing record', () => {
           let changed;
           beforeEach(() => {
-            changed = unshifted.records[1].content.concat('!!!');
+            changed = second(unshifted.records).content.concat('!!!');
           });
           it('changed new record', () => {
-            expect(changed.records[1].content.state).toBe('Herro!!!');
+            expect(second(changed.records).content.state).toBe('Herro!!!');
           });
         });
       });
@@ -273,11 +274,11 @@ describe("ArrayType", function() {
         describe('changing remaining item', () => {
           let changed;
           beforeEach(() => {
-            changed = filtered.records[0].content.concat('!!!');
+            changed = first(filtered.records).content.concat('!!!');
           });
 
           it('it changed the state', () => {
-            expect(changed.records[0].content.state).toBe('Sweet!!!');
+            expect(first(changed.records).content.state).toBe('Sweet!!!');
           });
         });
       });
@@ -290,19 +291,19 @@ describe("ArrayType", function() {
           });
 
           it('applied change to every element', () => {
-            expect(mapped.records[0].content.state).toBe('Herro!!!');
-            expect(mapped.records[1].content.state).toBe('Sweet!!!');
-            expect(mapped.records[2].content.state).toBe('Woooo!!!');
+            expect(first(mapped.records).content.state).toBe('Herro!!!');
+            expect(second(mapped.records).content.state).toBe('Sweet!!!');
+            expect(third(mapped.records).content.state).toBe('Woooo!!!');
           });
 
           describe('changing record', () => {
             let changed;
             beforeEach(() => {
-              changed = mapped.records[1].content.set('SWEET!!!');
+              changed = second(mapped.records).content.set('SWEET!!!');
             });
 
             it('changed the record content', () => {
-              expect(changed.records[1].content.state).toBe('SWEET!!!');
+              expect(second(changed.records).content.state).toBe('SWEET!!!');
             });
           });
         });
@@ -321,12 +322,12 @@ describe("ArrayType", function() {
           });
 
           it('changed type of the record', () => {
-            expect(mapped.records[1]).toBeInstanceOf(SweetSweetRecord);
+            expect(second(mapped.records)).toBeInstanceOf(SweetSweetRecord);
           });
 
           it('did not change the uneffected item', () => {
-            expect(dataset.records[0].state).toBe(mapped.records[0].state);
-            expect(dataset.records[2].state).toBe(mapped.records[2].state);
+            expect(first(dataset.records).state).toBe(mapped.records[0].state);
+            expect(third(dataset.records).state).toBe(mapped.records[2].state);
           });
         });
       });
@@ -345,8 +346,6 @@ describe("ArrayType", function() {
           expect(cleared.state).toEqual({ records: [] });
         });
       });
-
     });
-
   });
 });


### PR DESCRIPTION
When trying to use microstates in production the results have mixed. Not from an API perspective, but from a performance perspective. The problem is that when instantiating “container” microstates Array and Object, it’s really slow. The reason is because is it’s looking to instantiate _all_ of the substates eagerly, and set up all of the objects that _they_ contain. We can see by the bench marks that this is not good.

These operations on scalar values bottom out at `35k` operations per second.

```
┌────────┬───────────────────────────────────┬───────────┬──────────┬─────────────┐
│ Suite  │ Benchmark                         │ ops/sec   │ σ        │ sample size │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Any    │ create(Any)                       │ 2,512,336 │ ± 0.80 % │ 91          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Any    │ create(Any, 5)                    │ 2,359,540 │ ± 0.54 % │ 89          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Any    │ create(Any).set(5)                │ 422,734   │ ± 2.27 % │ 85          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Any    │ Store(create(Any))                │ 35,753    │ ± 2.44 % │ 76          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Any    │ Store(create(Any, 5))             │ 35,135    │ ± 1.95 % │ 85          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Any    │ Store(create().set(5))            │ 32,977    │ ± 1.71 % │ 76          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Number │ create(Number)                    │ 176,470   │ ± 1.02 % │ 87          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Number │ create(Number, 42)                │ 389,043   │ ± 0.53 % │ 87          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Number │ create(Number).set(42)            │ 102,410   │ ± 0.52 % │ 89          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Number │ Store(create(Number))             │ 24,502    │ ± 1.33 % │ 85          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Number │ Store(create(Number, 42))         │ 27,212    │ ± 1.44 % │ 88          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Number │ Store(create(Number)).set(42)     │ 18,895    │ ± 1.11 % │ 86          │
└────────┴───────────────────────────────────┴───────────┴──────────┴─────────────┘
```

compared with the results from array and object types you can see that we've got only 1 or 2 operations _per second_ in most cases:

```
┌────────┬───────────────────────────────────┬───────────┬──────────┬─────────────┐
│ Suite  │ Benchmark                         │ ops/sec   │ σ        │ sample size │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Array  │ create([], Array(100))            │ 2.33      │ ± 3.29 % │ 11          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Array  │ create([]).set(Array(100))        │ 2.33      │ ± 1.55 % │ 11          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Array  │ Store(create([]))                 │ 24,616    │ ± 1.69 % │ 84          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Array  │ Store(create([], Array(100)))     │ 2.31      │ ± 1.67 % │ 10          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Array  │ Store(create([]).set(Array(100))) │ 2.35      │ ± 2.49 % │ 10          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Object │ create({})                        │ 2,413,248 │ ± 0.79 % │ 89          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Object │ create({}).set({})                │ 413,903   │ ± 1.00 % │ 86          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Object │ create({}, BIGOBJECT)             │ 1.36      │ ± 1.75 % │ 8           │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Object │ create({}).set(BIGOBJECT)         │ 1.34      │ ± 1.45 % │ 8           │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Object │ Store(create({}))                 │ 29,737    │ ± 1.52 % │ 83          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Object │ Store(create({}, BIGOBJECT))      │ 1.34      │ ± 3.07 % │ 8           │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Object │ Store(create({}).set(BIGOBJECT))  │ 1.32      │ ± 2.32 % │ 8           │
└────────┴───────────────────────────────────┴───────────┴──────────┴─────────────┘
```

Frankly that's abysmal, and it's work that we can avoid. For example, let's say we have an array microstate that looks like:

```js
const People = [class Person { name = String; age = Number }];
let kids = create(People, [{name: 'Selma', age: 3}, {name: 'Niilo', age: 9}, {name: 'Saara', age: 7}]);
```

This actually ends up calling create 4 times: once for the `People` object and three more times for the `Person`. If you imagine there being an array of 3 or 400 elements, then we're talking quite a bit of work that's happening just to wrap a microstate around a value.

What if, on the other hand, we could call:

```js
let kids = create(People, [{name: 'Selma', age: 3}, {name: 'Niilo', age: 9}, {name: 'Saara', age: 7}]); // no-op
```

and absolutely _nothing_ would happen except instantiating the `People` microstate? In that case, only when we want to iterate over all the people, would we create the array microstates.

```js
for (let kid of kids) {
  //kid is instantiated right before this.
}

kids.map(kid => kid.age.increment(1)); //kid instantiated right before calling mapping function.
```

### Approach

As mentioned, we want to defer to creating the contained microstate for as long as possible. In other words, it doesn't exist until somebody actually wants to _do_ something with it. In other words: lazy as hell. 

One immediate consequence is that there is no more accessing an Array microstate by number index. There's no way to do that lazily without a [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy). In order to say `kids[1]` you'd need to already have the object at `kids[1]` created _before_ calling it. That's ok, because we're encouraging FP practices anyhow, and so instead of reading indices directly, we'll have things set up to fold, filter, iterate and map. In fact, it's an improvement.

For tests and just for playing around, there's no reason we can't have simple queries like: `first`, `second`, `slice`, and `at`

```js
let array = create([String], ['milk', 'cheese', 'bread']));

first(array)  //=> Microstate<String>{ state: 'milk' }
second(array) //=> Microstate<String>{ state: 'cheese' }
last(array) //=> Microstate<String>{ state: 'bread' }
at(1, array) //=> Microstate<String>{ state: 'cheese' }
slice(1, 2, array) //=> Microstate<Array<String>>{ state: ['cheese', 'bread'] }

/*length becomes a query*/

length(array) //=> 3
```

So we instantiate the contained microstates lazily. That's great for reads, but what about when we want to make changes to the substates. They have to be somehow "connected" to the greater tree. So for example, when we say:

```js
let one = at(0, array);
one.set('roquefort') //=> Microstate<Array<String>> { state: ['milk', 'roquefort', 'bread'] }
```

As it stands now, this `set` will work by using the `SubstateAt` lens, but that lens is predicated on _eager_ property access as can be seen by the current implementation:

```js
// these are paraphrased, but they contain the meat. 
// Basically context[name] and context[name] = value.
export function SubstateAt(name) {
  let getter = context => {
    return context[name];
  }

  let setter = (substate, microstate) => {
    return append(microstate, {
        [name]: Meta.treemap(meta => ({ path: [name].concat(meta.path) }), contextualized),
        state: set(ValueAt(name), substate.state, microstate.state)
      });
    }
  };

  return Lens(getter, setter);
}
```

In reality though, what we want is that a change in a substate just re-creates a fresh Array microstate that has the altered state. It's actually a simple change really. So if we have some substate in an array, the "meat" of the lens should be

```js
//get for Array<T>
export function ArrayAt(index) {
  function getter(array) {
    let substate = create(T, array.state[index]);
    return substate;
  }
  function setter(substate, arrayMicrostate) {
    return append(arrayMicrostate, {
      get state() {
        let nextState = arrayMicrostate.slice();
        nextState[index] = substate.state;
        return nextState;
      }
    }
  }
}
```

Notice how it isn't gotten until we actually ask for the substate at that index? By the same token, invoking an array transition (which calls the setter) just calculates the new state based on the substate.


There are two complication here though. Let's have a look at the getter:

```js
function getter(array) {
  let substate = create(T, array.state[index]);
  return substate;
}
```

The first complication is that the lens laws dictate that this operation should be stable. In other words, getting the index multiple times should return the exact same object. This is not that. This creates a new substate object every time, andimplies that in order to get it working properly, we'll need to somehow cache the value once we retrieve it. Basically, this needs to be true:

```js
let array = create([String], ['hello', 'world']);
view(ArrayAt(0), array) === view(ArrayAt(0), array) // must be true!
```

By the same token, if we set the substate to its current value, then we need to return the exact same array context. I don't see how we can do this without making sure that we cache values so that when we retrieve the current, we can compare it against the incoming. That's not feasible if retrieving the current substate is always computing a new value.

> Side note. Could this caching layer be baked in at the lens layer? I.e. the whole meta-mechanism that actually is `over` and `set`? I don't know, but it's something to consider. That would be wicked cool.

The second complication is that this new type of `ArrayAt` lens needs to be the primary lens of the substate, and it needs to be composed with the all of the lenses of the substate. Right now the way this works is that the lens of each substate is just computed off of the paths:

```js

class Meta {
  get lens() {
    return SubstatePath(this.path);
  }
}
```

So each object in the entire hierarchy gets the same lens, which is just a series of `SubstateAt` lenses. This won't work for us, because our array children need to have the `ArrayAt` lens, not a `SubstateAt` lens.

Dynamically computing the lens as a pure function of the path worked when we had the same lens at each path, but now the lens can depend on the type of object on which it is being mounted. To deal with this, we'll implement a new typeclass called `At` which which types can _polymorphically_ describe how other objects are embedded inside them:

```js
let array = create([], [1, 2, 3]);
view(At(array, 0), array) //=> Microstate<Any>{ state: 1 }

let object = create({}, {hello: 'world'});
view(At(object, 'hello'), object) //=> Microstate<Any>{ state: 'world' }
```

So if we allow _how_ objects become embedded to vary by class, then we need to actually set the lens for a given object when it is embedded, not dynamically compute it based on the path. This means that there need to be some sort of `embed` operation that takes a microstate, a substate, and a key, and then _looks up_ the lens that'll be used to actually set that value going forward. Basically, the meat of what it currently at the `SubstateAt` lens:

```js
let contextualized = Meta.update(() => ({ source: substate }), substate);
let embedded = Meta.treemap(meta => ({ path: [name].concat(meta.path) }), contextualized),
```

### Implementation Plan

1. Change the API first. Remove index references to arrays in tests and replace them with calls to `first`, `second`, `third`, `at(i)`, and `last`.
2. Rather than dynamically compute lens off of path, compose lenses at "mount" time.
3. Introduce the `At` typeclass to dynamically look up how objects are embded into each other and use it to find which lens to compose at "mount" time. There is only one instance for `At` for all objects.
4. Differentiate `ArrayType` microstates with an instance of `At` that is internally efficient.
