### PR TITLE
Support non-transitions

### DIFF
--- a/src/microstates.js
+++ b/src/microstates.js
@@ -68,7 +68,7 @@ const toMicrostateType = stable(function toMicrostateType(Type) {
   let descriptors = Object.getOwnPropertyDescriptors(Type.prototype);
   let methods = Object.keys(descriptors).reduce((methods, name) => {
     let desc = descriptors[name];
-    if (name !== 'constructor' && name !== 'set' && typeof name === 'string' && typeof desc.value === 'function') {
+    if (name !== 'constructor' && name !== 'set' && typeof name === 'string' && typeof desc.value === 'function' && !desc.value.nonTransition) {
       return methods.concat(name);
     } else {
       return methods;

--- a/tests/microstates.test.js
+++ b/tests/microstates.test.js
@@ -159,4 +159,23 @@ describe("Microstates", () => {
       });
     });
   });
+
+  describe('Microstates with nonTransition methods', function() {
+    class Person {
+      firstName = [String]
+      lastName = [String]
+      fullName() {
+        return this.firstName.state + " " + this.lastName.state;
+      }
+    }
+    Person.prototype.fullName.nonTransition = true;
+
+    let person;
+    beforeEach(function() {
+      person = create(Person, { firstName: 'Homer', lastName: 'Simpson' });
+    });
+    it('does now wrap the return as a Microstate', function() {
+      expect(person.fullName()).toEqual("Homer Simpson");
+    });
+  });
 })


### PR DESCRIPTION
Perhaps this violates the ideal of this project, but I think in some cases it is useful to have methods that are not transitions (or at least have the ability to return a value other than the `microstate` state). For simplicity the test-case in this PR is something that could be accomplished with a `getter` (which do not appear to be transformed into transitions).  Our actual use-case is a bit more complex but I could describe it if it helps explain why this would be useful.

The `nonTransition` marker would be more conveniently implemented as a decorator but I opted to not use them in the test-case because it's not a settled feature and the change in proposed syntax makes things complicated there.

The `nonTransition` name is just a placeholder.  If this idea is palatable we can choose an ideal name.
