### PR TITLE
Ability to lazily extend trees of microstates via `mount`

### DIFF
--- a/src/types/array.js
+++ b/src/types/array.js
@@ -1,5 +1,5 @@
 import { Assemble } from '../assemble';
-import { create, SubstateAt, Meta } from "../microstates";
+import { create, Meta } from "../microstates";
 import { set } from "../lens";
 import { Reducible } from '../../src/query';
 import { Filterable } from 'funcadelic';
@@ -53,7 +53,7 @@ export default parameterized(T => class ArrayType {
           microstate.state = [value];
         }
         return microstate.state.reduce((microstate, member, index) => {
-          return set(SubstateAt(index), create(T).set(member), microstate);
+          return set(Meta.At(index), create(T).set(member), microstate);
         }, microstate);
       }
     });

--- a/src/types/object.js
+++ b/src/types/object.js
@@ -1,5 +1,5 @@
 import { Assemble } from '../assemble';
-import { SubstateAt, create } from '../microstates';
+import { create, Meta } from '../microstates';
 import { over } from '../lens';
 import { append, filter, foldl } from 'funcadelic';
 import parameterized from '../parameterized'
@@ -18,7 +18,7 @@ export default parameterized(T => class ObjectType {
           microstate.state = {};
         }
         return foldl((microstate, entry) => {
-          return over(SubstateAt(entry.key), () => create(T).set(entry.value), microstate );
+          return over(Meta.At(entry.key), () => create(T).set(entry.value), microstate );
         }, microstate, microstate.state);
       }
     });

--- a/tests/initialization.test.js
+++ b/tests/initialization.test.js
@@ -65,22 +65,24 @@ describe('initialization', () => {
   });
 
   describe("deeply nested", () => {
+
     class Root {
-      first = create(class First {
-        second = create(class Second {
-          name = create(class StringType {
-            concat(value) {
-              return String(this.state).concat(String(value));
-            }
-          });
-          initialize(props) {
-            if (!props) {
-              return create(Second, { name: "default" });
-            }
-            return this;
-          }
-        });
-      });
+      first = First;
+    }
+
+    class First {
+      second = Second;
+    }
+
+    class Second {
+      name = String;
+
+      initialize(props) {
+        if (!props) {
+          return create(Second, { name: "default" });
+        }
+        return this;
+      }
     }
 
     describe('initialization', () => {
@@ -88,6 +90,13 @@ describe('initialization', () => {
 
       beforeEach(() => {
         root = create(Root, { first: { } });
+      });
+
+      it('maintains the === integrity of the state tree', function() {
+        expect(root.state).toBe(root.state);
+        expect(root.first.state).toBe(root.state.first);
+        expect(root.first.second.state).toBe(root.state.first.second);
+        expect(root.first.second.name.state).toBe(root.state.first.second.name);
       });
 
       it("has result of create of second node", () => {
@@ -104,7 +113,6 @@ describe('initialization', () => {
 
         let changed;
         beforeEach(() => {
-
           changed = root.first.second.name.concat("!!!");
         });
 

--- a/tests/lens.test.js
+++ b/tests/lens.test.js
@@ -1,7 +1,7 @@
 import expect from 'expect';
-import { compose, view, over, set, Prop, Path, transparent, Lens } from '../src/lens';
+import { view, set } from '../src/lens';
 import { append } from 'funcadelic';
-import { create, SubstateAt } from '../src/microstates';
+import { create, Meta } from '../src/microstates';
 
 describe('substate lenses', function() {
   class Parent {}
@@ -10,7 +10,7 @@ describe('substate lenses', function() {
   let parent = new Parent();
   let lens
   beforeEach(function() {
-    lens = SubstateAt('child');
+    lens = Meta.At('child');
   });
 
   it('set-get: view retrievs what set put in', function() {

--- a/tests/mount.test.js
+++ b/tests/mount.test.js
@@ -1,0 +1,84 @@
+import expect from 'expect';
+import { create } from '../index';
+import { Meta } from '../src/microstates';
+import { set } from '../src/lens';
+
+const { mount, At } = Meta;
+
+describe('mounting', function() {
+
+  class Node {}
+  let parent;
+  beforeEach(function() {
+    parent = create(Node);
+    parent.child = mount(parent, 'child', create(Node));
+  });
+
+  it('focuses the lens of this structure to return the containing state', function() {
+    expect(parent.child.set('Ricardio')).toEqual({
+      state: {
+        child: 'Ricardio'
+      },
+      child: {
+        state: 'Ricardio'
+      }
+    })
+  });
+
+  describe('nested mounting', function() {
+    let child, grandchild;
+    beforeEach(function() {
+      grandchild = parent.child.grandchild = mount(parent.child, 'grandchild', create(Node));
+    });
+
+    it('transitions from the grandchild to the root', function() {
+      let transitioned = grandchild.set('Barry');
+      expect(transitioned).toEqual({
+        state: {
+          child: {
+            grandchild: 'Barry'
+          }
+        },
+        child: {
+          state: { grandchild: 'Barry' },
+          grandchild: {
+            state: 'Barry'
+          }
+        }
+      })
+    });
+    it('tolerates multiple transitions', function() {
+      let transitioned = grandchild.set('Barry').child.grandchild.set('Larry');
+      expect(transitioned).toEqual({
+        state: {
+          child: {
+            grandchild: 'Larry'
+          }
+        },
+        child: {
+          state: { grandchild: 'Larry' },
+          grandchild: {
+            state: 'Larry'
+          }
+        }
+      })
+    });
+    it('tolerates multiple transitions at different levels of the tree', function() {
+      let transitioned = grandchild.set('Barry').child.grandchild.set('Larry');
+      expect(transitioned).toEqual({
+        state: {
+          child: {
+            grandchild: 'Larry'
+          }
+        },
+        child: {
+          state: { grandchild: 'Larry' },
+          grandchild: {
+            state: 'Larry'
+          }
+        }
+      })
+    });
+  });
+
+});

--- a/tests/parameterized.test.js
+++ b/tests/parameterized.test.js
@@ -68,7 +68,7 @@ describe("Parameterized Microstates: ", () => {
         transitioned = m.apples[0].increment().oranges[1].increment();
       });
       it("uses the same value for state as the value ", function() {
-        expect(m.state).toEqual(value);
+        expect(m.state).toBe(value);
       });
       it("still respects transitions", function() {
         let value = {


### PR DESCRIPTION
## Purpose

Currently in microstates, the construction of the entire tree is eager. So for any microstate, object, array, or custom type, it iterates over the substates, and then initializes those completely, and then sets them as properties. It was necessary to do this because the tree was built from the bottom up and the context needed to be re-mapped at each adittional step.

In other words, in order to add a child node to a node `A`, you actually needed to know what that child node would be before you could generated a node `A'` which had that node as a child.

This requirement causes some performance issues, especially with container components since you have to instantiate every single object in the tree before you can do anything with the tree.

## Approach

This introduces a `mount` method that lets you derive child states of `A` that when they are transitioned, they return a new version of `A` that contains the transitioned child. The key part is that `A` does not need to know _anything_ about children that might be mounted on it.

For example, let's say I have two microstates, `Counter` and `Number`:

```js
let counter = create(class Counter {}, {});
let count = create(Number, 5);
```

These states don't know anything about each other, but I can "mount" the count onto the counter.

```js
let mounted = Meta.mount(counter, 'count', count);
```
This does not change the `counter` object at all, nor does it change the `count` object. Instead it returns a new microstate, just like `count` in every way except that its transitions will return a new version of the `Counter` object just like the parent, except that the `count` property will be set to the newly transitioned number.

```js
mounted.increment();
/**
 *  Microstate<Counter> {
 *    count: Microstate<Number>{ state: 6 }
 *    state: { count: 6
 *  }
 */
```

This is powerful because it means that any microstate can be extended with children without any prior knowledge of what children can be present and for very little computational cost.

That doesn't mean that this approach is incompatible with prior knowledge of which children will be present. In fact, that's core to microstates... accessing children from the parent.

All it takes is providing a vector to do that computaiton. For example, we can make the count accessible from the counter simply by adding it as a lazy, computed property:

```js
counter = append(counter, {
  get count() {
    return Meta.mount(this, 'count', count);
  }
})

counter.count.increment();
/**
 *  Microstate<Counter> {
 *    count: Microstate<Number>{ state: 6 }
 *    state: { count: 6
 *  }
 */
```

In essence, the computation of the children can be deferred, and so for things like arrays which could potentially contain hundreds if not thousands of items, this represents a major potential costs savings.

Note that this is just a precursor to better performance for Objects, and especially Arrays because in order to provide direct keyed access to arrays, you still need to eagerly define all of the properties in an array, so for an array of 100 elements, we are still defining 100 computed properties for "0".."100" However, once we remove the direct access api and require consuming code to use the iterable protocol, we can avoid this step entirely.

Even without this follow-on work, the speedup on benchmarks is around 50x-100x

Before:

```
┌────────┬───────────────────────────────────┬───────────┬──────────┬─────────────┐
│ Suite  │ Benchmark                         │ ops/sec   │ σ        │ sample size │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Array  │ create([], Array(100))            │ 2.33      │ ± 3.29 % │ 11          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Array  │ create([]).set(Array(100))        │ 2.33      │ ± 1.55 % │ 11          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Array  │ Store(create([], Array(100)))     │ 2.31      │ ± 1.67 % │ 10          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Array  │ Store(create([]).set(Array(100))) │ 2.35      │ ± 2.49 % │ 10          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Object │ create({}, BIGOBJECT)             │ 1.36      │ ± 1.75 % │ 8           │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Object │ create({}).set(BIGOBJECT)         │ 1.34      │ ± 1.45 % │ 8           │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Object │ Store(create({}))                 │ 29,737    │ ± 1.52 % │ 83          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Object │ Store(create({}, BIGOBJECT))      │ 1.34      │ ± 3.07 % │ 8           │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Object │ Store(create({}).set(BIGOBJECT))  │ 1.32      │ ± 2.32 % │ 8           │
└────────┴───────────────────────────────────┴───────────┴──────────┴─────────────┘
```

After:

```
┌────────┬───────────────────────────────────┬───────────┬──────────┬─────────────┐
│ Suite  │ Benchmark                         │ ops/sec   │ σ        │ sample size │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Array  │ create([], Array(100))            │ 101       │ ± 4.33 % │ 66          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Array  │ create([]).set(Array(100))        │ 109       │ ± 3.27 % │ 64          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Array  │ Store(create([], Array(100)))     │ 48.09     │ ± 3.26 % │ 63          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Array  │ Store(create([]).set(Array(100))) │ 47.73     │ ± 3.42 % │ 62          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Object │ create({}, BIGOBJECT)             │ 85.81     │ ± 4.55 % │ 56          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Object │ create({}).set(BIGOBJECT)         │ 84.14     │ ± 4.47 % │ 55          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Object │ Store(create({}, BIGOBJECT))      │ 39.49     │ ± 2.61 % │ 51          │
├────────┼───────────────────────────────────┼───────────┼──────────┼─────────────┤
│ Object │ Store(create({}).set(BIGOBJECT))  │ 39.49     │ ± 2.96 % │ 52          │
└────────┴───────────────────────────────────┴───────────┴──────────┴─────────────┘
```

Not too shabby ;-)