### PR TITLE
Simplify Meta constructor.

### DIFF
--- a/src/microstates.js
+++ b/src/microstates.js
@@ -92,10 +92,10 @@ export function isMicrostate(value) {
 }
 
 export class Meta {
-  constructor(attrs = {}) {
-    this.path = attrs.hasOwnProperty('path') ? attrs.path : [];
-    this.context = attrs.hasOwnProperty('context') ? attrs.context : undefined;
-    this.lens = attrs.hasOwnProperty('lens') ? attrs.lens : transparent;
+  constructor(object) {
+    this.context = object;
+    this.path = [];
+    this.lens = transparent;
   }
 
   static get(object) {
@@ -161,7 +161,7 @@ export class Meta {
   }
 
   static lookup(object) {
-    return object[Meta.LOOKUP] || new Meta({ context: object });
+    return object[Meta.LOOKUP] || new Meta(object);
   }
 
   static LOOKUP = Symbol('Meta');


### PR DESCRIPTION
With the move to lazyily mounted microstates, there are a couple of key changes:

1. meta.lens is not a computed property. Instead, it is manually composed as a function ahead of time.
2. The only time that a meta is constructed it is done with the object for which the meta will for. All subsequent meta objects are derived from that original meta.

As a result, we can move away from the "configuration based" constructor where you can pass in any number of attributes which are queried, and just use a simple direct assignment.

Path always starts out as `[]` and the lens always starts out as `transparent`.