### PR TITLE
Add benchmarks for TodoMVC.

### DIFF
--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -3,6 +3,7 @@ import any from './any.benchmark'
 import number from './number.benchmark';
 import array from './array.benchmark';
 import object from './object.benchmark';
+import todomvc from './todomvc.benchmark';
 
 import Benchmark from 'benchmark';
 import Table from 'cli-table';
@@ -44,5 +45,6 @@ any(suite);
 number(suite);
 array(suite);
 object(suite);
+todomvc(suite);
 
 suite.run({ async: true });

--- a/benchmarks/todomvc.benchmark.js
+++ b/benchmarks/todomvc.benchmark.js
@@ -1,0 +1,23 @@
+import { Store, create } from '../index';
+import benchmark from './benchmark';
+import { TodoMVC } from '../tests/todomvc';
+
+
+const MUCH_TODO = { todos: [] };
+for (let i = 0; i < 100; i++) {
+  MUCH_TODO.todos.push({
+    title: 'Todo #{i}',
+    completed: Math.random() > 0.5 ? true : false
+  })
+}
+const ONE_MORE_TODO = { title: 'One more thing', completed: false };
+
+export default benchmark('TodoMVC', function(suite) {
+  suite.add('Store(create(TodoMVC, MUCH_TODO)); //100 todos', () => {
+    Store(create(TodoMVC, MUCH_TODO));
+  });
+  let store = create(TodoMVC, MUCH_TODO);
+  suite.add('store.todos.push(ONE_MORE_TODO); //add to a list of 100', () => {
+    store.todos.push(ONE_MORE_TODO);
+  })
+});


### PR DESCRIPTION
## Purpose

We've been working on a bunch of performance fixes by making the properties of all microstates (normal, object, and array) lazy. We've also been making the store lazy as a performance booster. We need a way to measure the improvements against how they actually would look in a microstates application though and not just create empty stores or meaningless arrays. We need a benchmark that simulates something approaching a real usage.

## Approach

The TodoMVC app, which is already used in our tests is very close to what you would see in an application. It has an item model, and a list model that tracks those items.

In order to simulate production usage, there are two cases that we want to capture: initialization, and addition. This is because every application has to start with an beginning state. It cannot be prohibitively expensive to initialize a store with existing application state. Also, it cannot be prohibitively expensive to add items or take them away because that's the UX right there. If it's slow, then it's a no-go.

These benchmarks highlight the current performance problems so that any solution can be measured against them.

```
┌────────────┬─────────────────────────────────────────────────────────┬───────────┬──────────┬─────────────┐
│ Suite      │ Benchmark                                               │ ops/sec   │ σ        │ sample size │
├────────────┼─────────────────────────────────────────────────────────┼───────────┼──────────┼─────────────┤
│ TodoMVC    │ Store(create(TodoMVC, MUCH_TODO)); //100 todos          │ 5.38      │ ± 3.15 % │ 19          │
├────────────┼─────────────────────────────────────────────────────────┼───────────┼──────────┼─────────────┤
│ TodoMVC    │ store.todos.push(ONE_MORE_TODO); //add to a list of 100 │ 36.64     │ ± 2.32 % │ 49          │
└────────────┴─────────────────────────────────────────────────────────┴───────────┴──────────┴─────────────┘
```
## Implementation notes.

We picked 100 as the number todos that we tested against. We actually tried more than that, but the benchmarks never could even complete a single revolution.

Going lazy is not just for performance. It will allow us to have recursive and circular microstates. E.g.

```js
class Tree {
  content = Object;
  children = [Tree];
}
```

## Further Exploration

The total suite of benchmarks that run here takes upwards of 3 minutes to run. We could think about removing some of them as they seem redundant.