### PR TITLE
Bring back observable integration.

### DIFF
--- a/src/microstates.js
+++ b/src/microstates.js
@@ -5,6 +5,7 @@ import { methodsOf } from './reflection';
 import dsl from './dsl';
 import Any from './types/any';
 import CachedProperty from './cached-property';
+import Observable from './observable';
 
 export function create(InputType = Any, value) {
   let { Type } = dsl.expand(InputType);
@@ -21,7 +22,7 @@ const MicrostateType = stable(function MicrostateType(Type) {
   if (Type.Type) {
     return Type;
   }
-  let Microstate = class extends Type {
+  let Microstate = class extends Observable(Type) {
     static name = `Microstate<${Type.name}>`;
     static Type = Type;
 
@@ -61,7 +62,6 @@ const MicrostateType = stable(function MicrostateType(Type) {
       }
     }
   }, methodsOf(Type)))
-
   return Microstate;
 })
 

--- a/src/observable.js
+++ b/src/observable.js
@@ -1,0 +1,19 @@
+import Identity from './identity';
+import SymbolObservable from 'symbol-observable';
+
+export default function Observable(Microstate) {
+  return class extends Microstate {
+    [SymbolObservable]() { return this['@@observable'](); }
+    ['@@observable']() {
+      return {
+        subscribe: (observer) => {
+          let next = observer.call ? observer : observer.next.bind(observer);
+          return Identity(this, next);
+        },
+        [SymbolObservable]() {
+          return this;
+        }
+      };
+    }
+  }
+}

--- a/tests/observable.test.js
+++ b/tests/observable.test.js
@@ -1,188 +1,180 @@
-// import expect from 'expect';
-// import { create } from "../src/microstates";
-// import ArrayType from "../src/types/array";
-// import SymbolObservable from 'symbol-observable';
-// import { from } from 'rxjs';
+import expect from 'expect';
+import { create } from "../src/microstates";
+import { valueOf } from "../src/meta";
+import ArrayType from "../src/types/array";
+import SymbolObservable from 'symbol-observable';
+import { from } from 'rxjs';
 
-// class NumberType {
-//   initialize(value) {
-//     return Number(value);
-//   }
-//   increment() {
-//     return this.state + 1;
-//   }
-// }
+describe('rxjs interop', function() {
+  let ms, observable, observer, last;
+  let observerCalls;
+  beforeEach(() => {
+    observerCalls = 0;
+    ms = create(Number, 42);
+    observer = next => {
+      observerCalls++;
+      return last = next;
+    };
 
-// describe('rxjs interop', function() {
-//   let ms, observable, observer, last;
-//   let observerCalls;
-//   beforeEach(() => {
-//     observerCalls = 0;
-//     ms = create(NumberType, 42);
-//     observer = next => {
-//       observerCalls++;
-//       return last = next;
-//     };
+    observable = from(ms);
+    let subscription = observable.subscribe(observer);
 
-//     observable = from(ms);
-//     let subscription = observable.subscribe(observer);
+    last.increment();
+    last.increment();
+    last.increment();
+  });
+  it('sent 4 states to obsever', function() {
+    expect(observerCalls).toBe(4);
+  });
+  it('incremented 3 times', function() {
+    expect(valueOf(last)).toBe(45);
+  });
+});
 
-//     last.increment();
-//     last.increment();
-//     last.increment();
-//   });
-//   it('sent 4 states to obsever', function() {
-//     expect(observerCalls).toBe(4);
-//   });
-//   it('incremented 3 times', function() {
-//     expect(last.state).toBe(45);
-//   });
-// });
+describe('interop', function() {
+  let ms, observable;
+  beforeEach(() => {
+    ms = create(Number, 10);
+    observable = ms[SymbolObservable]();
+  });
 
-// describe('interop', function() {
-//   let ms, observable;
-//   beforeEach(() => {
-//     ms = create(NumberType, 10);
-//     observable = ms[SymbolObservable]();
-//   });
+  it('observable has subscribe', () => {
+    expect(observable.subscribe).toBeInstanceOf(Function);
+  });
 
-//   it('observable has subscribe', () => {
-//     expect(observable.subscribe).toBeInstanceOf(Function);
-//   });
+  it('observable has reference to self', () => {
+    expect(observable[SymbolObservable]()).toBe(observable);
+  });
+});
 
-//   it('observable has reference to self', () => {
-//     expect(observable[SymbolObservable]()).toBe(observable);
-//   });
-// });
+describe("initial value", function() {
+  let observable, last, unsubscribe;
+  beforeEach(function() {
+    let ms = create(Number, 10);
+    observable = ms[SymbolObservable]();
+    observable.subscribe(v => (last = v));
+  });
+  it("comes from microstate", function() {
+    expect(last.state).toBe(10);
+  });
+});
 
-// describe("initial value", function() {
-//   let observable, last, unsubscribe;
-//   beforeEach(function() {
-//     let ms = create(NumberType, 10);
-//     observable = ms[SymbolObservable]();
-//     observable.subscribe(v => (last = v));
-//   });
-//   it("comes from microstate", function() {
-//     expect(last.state).toBe(10);
-//   });
-// });
+describe("single transition", function() {
+  let observable, last, unsubscribe;
+  beforeEach(function() {
+    let ms = create(Number, 10);
+    observable = ms[SymbolObservable]();
+    observable.subscribe(v => (last = v));
+    last.increment();
+  });
+  it("gets next value after increment", function() {
+    expect(last.state).toBe(11);
+  });
+});
 
-// describe("single transition", function() {
-//   let observable, last, unsubscribe;
-//   beforeEach(function() {
-//     let ms = create(NumberType, 10);
-//     observable = ms[SymbolObservable]();
-//     observable.subscribe(v => (last = v));
-//     last.increment();
-//   });
-//   it("gets next value after increment", function() {
-//     expect(last.state).toBe(11);
-//   });
-// });
+describe("many transitions", function() {
+  let observable, last, unsubscribe;
+  beforeEach(function() {
+    let ms = create(Number, 10);
+    observable = ms[SymbolObservable]();
+    observable.subscribe(v => (last = v));
+    last
+      .increment()
+      .increment()
+      .increment();
+  });
+  it("gets next value after multiple increments", function() {
+    expect(last.state).toBe(13);
+  });
+});
 
-// describe("many transitions", function() {
-//   let observable, last, unsubscribe;
-//   beforeEach(function() {
-//     let ms = create(NumberType, 10);
-//     observable = ms[SymbolObservable]();
-//     observable.subscribe(v => (last = v));
-//     last
-//       .increment()
-//       .increment()
-//       .increment();
-//   });
-//   it("gets next value after multiple increments", function() {
-//     expect(last.state).toBe(13);
-//   });
-// });
+describe("complex type", function() {
+  class A {
+    b = create(class B {
+      c = create(class C {
+        values = create(ArrayType);
+      });
+    });
+  }
 
-// describe("complex type", function() {
-//   class A {
-//     b = create(class B {
-//       c = create(class C {
-//         values = create(ArrayType);
-//       });
-//     });
-//   }
+  let observable, last;
+  beforeEach(function() {
+    let ms = create(A, { b: { c: { values: ["hello", "world"] } } });
+    observable = ms[SymbolObservable]();
+    observable.subscribe(v => (last = v));
+  });
 
-//   let observable, last;
-//   beforeEach(function() {
-//     let ms = create(A, { b: { c: { values: ["hello", "world"] } } });
-//     observable = ms[SymbolObservable]();
-//     observable.subscribe(v => (last = v));
-//   });
+  it("has deeply nested transitions", function() {
+    expect(last.b.c.values.push).toBeInstanceOf(Function);
+  });
 
-//   it("has deeply nested transitions", function() {
-//     expect(last.b.c.values.push).toBeInstanceOf(Function);
-//   });
+  describe("invoking deeply nested", function() {
+    beforeEach(function() {
+      last.b.c.values.push("!!!");
+    });
+    it("changed the state", function() {
+      expect(valueOf(last.b.c.values)).toEqual(["hello", "world", "!!!"]);
+    });
+  });
+});
 
-//   describe("invoking deeply nested", function() {
-//     beforeEach(function() {
-//       last.b.c.values.push("!!!");
-//     });
-//     it("changed the state", function() {
-//       expect(last.state.b.c.values).toEqual(["hello", "world", "!!!"]);
-//     });
-//   });
-// });
+describe('initialized microstate', () => {
+  let call;
+  class Modal {
+    isOpen = create(class BooleanType {});
 
-// describe('initialized microstate', () => {
-//   let call;
-//   class Modal {
-//     isOpen = create(class BooleanType {});
+    initialize(value) {
+      if (!value) {
+        return create(Modal, { isOpen: true });
+      }
+      return this;
+    }
+  }
 
-//     initialize(value) {
-//       if (!value) {
-//         return create(Modal, { isOpen: true });
-//       }
-//       return this;
-//     }
-//   }
+  it('streams initialized microstate', () => {
+    let calls = 0;
+    let state;
+    let call = function call(next) {
+      calls++;
+      state = valueOf(next);
+    }
+    from(create(Modal)).subscribe(call);
+    expect(calls).toBe(1);
+    expect(state).toEqual({
+      isOpen: true
+    });
+  });
+});
 
-//   it('streams initialized microstate', () => {
-//     let calls = 0;
-//     let state;
-//     let call = function call(next) {
-//       calls++;
-//       state = next.state
-//     }
-//     from(create(Modal)).subscribe(call);
-//     expect(calls).toBe(1);
-//     expect(state).toEqual({
-//       isOpen: true
-//     });
-//   });
-// });
+describe('array as root', () => {
+  let list;
+  beforeEach(() => {
+    list = create(ArrayType, [{ hello: 'world' }]);
+  });
 
-// describe('array as root', () => {
-//   let list;
-//   beforeEach(() => {
-//     list = create(ArrayType, [{ hello: 'world' }]);
-//   });
+  it('has array with one element', () => {
+    expect(list.length).toBe(1);
+    expect([...list][0].state.hello).toBeDefined();
+  });
 
-//   it('has array with one element', () => {
-//     expect(list.state.length).toBe(1);
-//     expect(list[0].state.hello).toBeDefined();
-//   });
+  describe('created observable', () => {
+    let observable, last, isCalledCallback;
+    beforeEach(() => {
+      observable = from(list);
+      observable.subscribe(next => {
+        isCalledCallback = true;
+        last = next;
+      });
+    });
 
-//   describe('created observable', () => {
-//     let observable, last, isCalledCallback;
-//     beforeEach(() => {
-//       observable = from(list);
-//       observable.subscribe(next => {
-//         isCalledCallback = true;
-//         last = next;
-//       });
-//     });
+    it('called callback', () => {
+      expect(isCalledCallback).toBe(true);
+    });
 
-//     it('called callback', () => {
-//       expect(isCalledCallback).toBe(true);
-//     });
+    it('has array with one element', () => {
+      expect(last.length).toBe(1);
+      expect([...last][0].state.hello).toBeDefined();
+    });
+  });
 
-//     it('has array with one element', () => {
-//       expect(last.state.length).toBe(1);
-//       expect(last[0].state.hello).toBeDefined();
-//     });
-//   });
-
-// });
+});


### PR DESCRIPTION
As part of the femtostates refactor, support for `Symbol.observable` was removed. This brings it back.

There was talk about whether to put it directly on the `store` to support cursors, but for the moment, I think it wise to just not change to much at one time.

This maintains the original API 100%

When we have a nice think about how we want to maintain observable pointers deep into the tree and how that will work, then we can talk about breaking the API. Until then, let's keep it as a variable that doesn't move.