### PR TITLE
Adjust bundle size in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ With Microstates added to your project, you get:
 * 🎯 Transpilation free type system
 * 🔭 Optional integration with Observables
 * ⚛ Use in Node.js, browser or React Native
-* 🔬 Only [5.8kB gzipped](https://bundlephobia.com/result?p=microstates) with all dependencies
+* 🔬 Only [4.7kB gzipped](https://bundlephobia.com/result?p=microstates) with all dependencies
 
 But, most imporantly, Microstates makes working with state fun.
 


### PR DESCRIPTION
With the movement to a fully lazy architecture, we've reduced the web bundle size by about 20% to 3.78KB in the nodejs bundle and 4.74KB in the web bundle.

```text
index.js → dist/microstates.cjs.js...
┌──────────────────────────────────────────┐
│                                          │
│   Destination: dist/microstates.cjs.js   │
│   Bundle Size:  22.55 KB                 │
│   Minified and Gzipped Size:  3.68 KB    │
│                                          │
└──────────────────────────────────────────┘

index.js → dist/microstates.es.js...
┌─────────────────────────────────────────┐
│                                         │
│   Destination: dist/microstates.es.js   │
│   Bundle Size:  34.46 KB                │
│   Minified and Gzipped Size:  4.74 KB   │
│                                         │
└─────────────────────────────────────────┘
```