### PR TITLE
Export builtin types.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,3 +3,4 @@ export { default as from } from './src/literal';
 export { map, filter, reduce } from './src/query';
 export { default as Store } from './src/identity';
 export { metaOf, valueOf } from './src/meta';
+export * from './src/types';

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -10,4 +10,13 @@ describe('package', () => {
   it('exports store', () => expect(exports.Store).toBeInstanceOf(Function));
   it('exports metaOf', () => expect(exports.metaOf).toBeInstanceOf(Function));
   it('exports valueOf', () => expect(exports.valueOf).toBeInstanceOf(Function));
+  it('exports types', () => {
+    expect(exports.Any).toBeInstanceOf(Function);
+    expect(exports.Primitive).toBeInstanceOf(Function);
+    expect(exports.ObjectType).toBeInstanceOf(Function);
+    expect(exports.ArrayType).toBeInstanceOf(Function);
+    expect(exports.NumberType).toBeInstanceOf(Function);
+    expect(exports.StringType).toBeInstanceOf(Function);
+    expect(exports.BooleanType).toBeInstanceOf(Function);
+  });
 });


### PR DESCRIPTION
Right now, there is no way to access the builtin types from within
microstates. That means, if you want to explicitly create an opaque
microstate, you need to say:

```js
let opaque = create();
```

Or, within a custom type:

```js
class Model {
  opaque = create();
}
```

But in fact, what's really being used is the `Any` type.

Also, with the upcoming advent of primitive vs non-primitive types (ones that have a `.state` property vs those that don't). If you want to implement your own primitive types, then you'll need to be able to extend from Primitive.

This change makes these builtin types available directly, so you can say:

```js
let opaque = create(Any);
```

or, like in this issue: https://github.com/microstates/microstates.js/issues/236 where we want to wrap our own primitive type.

Finally, this takes the step of exporting all of the builtin types so that they can be used and extended inside classes. Particularly it seems like there might be useful to programatically parameterize things like Object and Array microstates.

```js
import { ArrayType } from 'microstates';
let NumberArray = ArrayType.of(Number);
```

It also is a step towards making the dsl optional.