### PR TITLE
Make `ArrayType#map` function stable.

### DIFF
--- a/src/types/array.js
+++ b/src/types/array.js
@@ -1,5 +1,5 @@
 import { append } from 'funcadelic';
-import { Container, At } from '../lens';
+import { At, set } from '../lens';
 import { Profunctor, promap, mount, valueOf } from '../meta';
 import { create } from '../microstates';
 import parameterized from '../parameterized';
@@ -48,9 +48,11 @@ export default parameterized(T => class ArrayType {
   }
 
   map(fn) {
-    return valueOf(this).map((item, index) => {
-      return valueOf(fn(create(T, item)));
-    });
+    let list = valueOf(this);
+    return list.reduce((acc, item, index) => {
+      let mapped = valueOf(fn(create(T, item)));
+      return set(At(index, acc), mapped, acc);
+    }, list);
   }
 
   clear() {

--- a/tests/types/array.test.js
+++ b/tests/types/array.test.js
@@ -81,6 +81,14 @@ describe("ArrayType", function() {
       it("state", () => {
         expect(valueOf(mapped)).toEqual(["A", "B", "C"]);
       });
+
+      it("returns the same object if the same microstate is returned", () => {
+        expect(mapped.map(x => x)).toBe(mapped);
+      });
+
+      it("returns the same array microstate if all of the values in the underlying array remain the same", () => {
+        expect(mapped.map(valueOf)).toBe(mapped);
+      });
     });
   });
 


### PR DESCRIPTION
Basically, when using the `.map` method on an Array microstate it was always returning a new instance of the Array even if the contents were the same.  Instead we expect that setting a microstate to its existing value should result in the exact same microstate being returned.
This PR intends to fix that, addressing #238 in the process.

*Before*
`a === a.map(x => x) //=> false`

*After*
`a === a.map(x => x) //=> true`
