### PR TITLE
Make `ArrayType#filter` function stable.

### DIFF
--- a/src/types/array.js
+++ b/src/types/array.js
@@ -42,9 +42,11 @@ export default parameterized(T => class ArrayType {
   }
 
   filter(fn) {
-    return valueOf(this).reduce((filtered, item, index) => {
-      return fn(create(T, item)) ? filtered.concat(item) : filtered;
+    let list = valueOf(this);
+    let result = list.reduce((filtered, member) => {
+      return fn(create(T, member)) ? filtered.concat(member) : filtered;
     }, []);
+    return list.length === result.length ? this : result;
   }
 
   map(fn) {

--- a/src/types/array.js
+++ b/src/types/array.js
@@ -43,9 +43,7 @@ export default parameterized(T => class ArrayType {
 
   filter(fn) {
     let list = valueOf(this);
-    let result = list.reduce((filtered, member) => {
-      return fn(create(T, member)) ? filtered.concat(member) : filtered;
-    }, []);
+    let result = list.filter((member) => fn(create(T, member)));
     return list.length === result.length ? this : result;
   }
 

--- a/tests/types/array.test.js
+++ b/tests/types/array.test.js
@@ -69,6 +69,10 @@ describe("ArrayType", function() {
       it("state", () => {
         expect(valueOf(filtered)).toEqual(["b", "c"]);
       });
+
+      it("returns the same array microstate if all of the values in the underlying array remains the same", () => {
+        expect(filtered.filter(() => true)).toBe(filtered);
+      });
     });
 
     describe("map", () => {


### PR DESCRIPTION
When using the `.filter` method on an Array microstate it was always returning a new instance of the Array even if the contents were the same. Instead we expect that setting a microstate to its existing value should result in the exact same microstate being returned.
This PR intends to fix that, in much the same way it was fixed for `.map` in #239 

*Before*
`a === a.filter(() => true) //=> false`

*After*
`a === a.filter(() => true) //=> true`