### PR TITLE
Introduce `ArrayType#sort` method

### DIFF
--- a/src/types/array.js
+++ b/src/types/array.js
@@ -41,6 +41,12 @@ export default parameterized(T => class ArrayType {
     return [value, ...valueOf(this)];
   }
 
+  sort(compareFn) {
+    let init = valueOf(this);
+    let result = [...init].sort(compareFn);
+    return init.every((member, idx) => result[idx] === member) ? this : result;
+  }
+
   filter(fn) {
     let list = valueOf(this);
     let result = list.filter((member) => fn(create(T, member)));

--- a/tests/types/array.test.js
+++ b/tests/types/array.test.js
@@ -59,6 +59,23 @@ describe("ArrayType", function() {
       });
     });
 
+    describe("sort", () => {
+      let sorted;
+
+      beforeEach(() => {
+        let unsorted = create([String], ["c", "b", "a"]);
+        sorted = unsorted.sort();
+      });
+
+      it("has a value that is the sorted version of the original value", () => {
+        expect(valueOf(sorted)).toEqual(["a", "b", "c"]);
+      });
+
+      it("returns the same array microstate if all of the values in the underlying array remains the same", () => {
+        expect(sorted.sort()).toBe(sorted);
+      });
+    });
+
     describe("filter", () => {
       let filtered;
 


### PR DESCRIPTION
This PR introduces the `.sort` method to Microstates' `ArrayType`.
It's basically a passthrough of `Array.prototype.sort` with the benefit that if the result of the `.sort()` call matches the original state, the original microstate is returned.

```
let sorted = create(ArrayType, ["a", "b", "c"]);
sorted === sorted.sort() //=> true
```