### PR TITLE
Update badges to put best foot forward.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![npm](https://img.shields.io/npm/v/microstates.svg)](https://www.npmjs.com/package/microstates)
 [![bundle size (minified + gzip)](https://badgen.net/bundlephobia/minzip/microstates)](https://bundlephobia.com/result?p=microstates)
 [![Build Status](https://travis-ci.org/microstates/microstates.js.svg?branch=master)](https://travis-ci.org/microstates/microstates.js)
 [![Coverage Status](https://coveralls.io/repos/github/microstates/microstates.js/badge.svg?branch=master)](https://coveralls.io/github/microstates/microstates.js?branch=master)


### PR DESCRIPTION
The coverage level is inaccurate, and reflects poorly on the project. In fact, we're not running coverage reports at all, and if we were, I have to imagine that the coverage level would be higher than 71%.

This change removes the coverage badge entirely until we actually commit to checking code coverage.

It also add adds an npm version badge so that it's clear which version is the current one.

### Before
![image](https://user-images.githubusercontent.com/4205/47378613-e5f0fa80-d6b5-11e8-8a97-8abf0c198743.png)

### After
![image](https://user-images.githubusercontent.com/4205/47378588-d376c100-d6b5-11e8-82b2-83b92aaa1949.png)

resolves #196 