### PR TITLE
Introduce `ArrayType#slice` method

### DIFF
--- a/src/types/array.js
+++ b/src/types/array.js
@@ -41,6 +41,12 @@ export default parameterized(T => class ArrayType {
     return [value, ...valueOf(this)];
   }
 
+  slice(begin, end) {
+    let list = valueOf(this);
+    let result = list.slice(begin, end);
+    return list.length === result.length ? this : result;
+  }
+
   sort(compareFn) {
     let init = valueOf(this);
     let result = [...init].sort(compareFn);

--- a/tests/types/array.test.js
+++ b/tests/types/array.test.js
@@ -59,6 +59,21 @@ describe("ArrayType", function() {
       });
     });
 
+    describe("slice", () => {
+      let sliced;
+      beforeEach(() => {
+        sliced = ms.slice(1);
+      });
+
+      it("has a sliced segment of the original list", () => {
+        expect(valueOf(sliced)).toEqual(["b", "c"]);
+      });
+
+      it("returns the same array microstate if all of the values in the underlying array remains the same", () => {
+        expect(sliced.slice(0)).toBe(sliced);
+      });
+    });
+
     describe("sort", () => {
       let sorted;
 


### PR DESCRIPTION
Just like I've done with `.sort` in #245, I'm doing with the new `.slice` method on the `ArrayType` for microstates.
This is basically a passthrough of `Array.prototype.slice` with the benefit that if the result of the `.slice()` call matches the original state, the original microstate is returned.

```
let letters = create(ArrayType, ["a", "b", "c"]);
let someLetters = letters.slice(1);
someLetters === someLetters.slice(0); //=> true
```