### PR TITLE
Expose raw test command.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,9 @@ node_js:
   - "8"
   - "6"
 
-install:
-  - npm install -g npm@latest
-  - npm install -g coveralls
-  - npm install
-
-after_success: npm run coverage
-
-script:
-  - npm test
+after_success:
+  - yarn coverage
+  - yarn coveralls
 
 # Allow Travis tests to run in containers.
 sudo: false

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
   "repository": "git+ssh://git@github.com/microstates/microstates.js.git",
   "scripts": {
     "start": "node repl.js",
-    "test": "nyc --reporter=html --reporter=text mocha --recursive -r tests/setup tests",
-    "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "test": "mocha --recursive -r tests/setup tests",
+    "coverage": "nyc --reporter=html --reporter=text npm run test",
+    "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "build": "rollup -c",
     "bench": "node -r ./tests/setup benchmarks/index.js",
     "prepare": "npm run build",


### PR DESCRIPTION
Purpose
==

When we added coverage, it took over the test command so that coverage was being run on every since test run. However, when developing it's often very desirable to _not_ run coverage, only the test suite for two reasons:

1. The test suite without coverage takes < 1s to run on a 2018 macbook
pro, whereas it takes > 3s to run with coverage. 
2. It appends coverage data to the output no matter what, which can make it difficult to interpret focused tests.

Approach
==

This splints the test command into two commands "test" and "coverage". The "test" command is as it was before: just running the test suite. The "coverage" command runs the test command but with coverage, and then the "coverage" command becomes "coveralls" which actually posts the results of the coverage report.

Finally, to simplify the build commands, we switch to using yarn on travis since it requires less configuration out of the box.