### PR TITLE
Add a testcase for `literal(null)`

### DIFF
--- a/tests/literal.test.js
+++ b/tests/literal.test.js
@@ -20,6 +20,10 @@ describe('Literal Syntax', function() {
     expect(valueOf(literal({}).put('hello', 'world'))).toEqual({hello: 'world'});
   });
 
+  it('can create nulls', function() {
+    expect(valueOf(literal(null))).toEqual(null);
+  });
+
   it('can create arrays', function() {
     expect(valueOf(literal([]).push('hello').push('world'))).toEqual(['hello', 'world']);
   });


### PR DESCRIPTION
This PR addresses an untested line of code uncovered by the new coverage report as stated in the issue that this will solve --> #252 