### PR TITLE
Identity should not call observer on creation

### DIFF
--- a/src/identity.js
+++ b/src/identity.js
@@ -89,7 +89,8 @@ export default function Identity(microstate, observe = x => x) {
 
     return Id;
   }
-  return tick(microstate);
+  update(microstate);
+  return identity;
 }
 
 function equals(id, other) {

--- a/src/observable.js
+++ b/src/observable.js
@@ -8,7 +8,9 @@ export default function Observable(Microstate) {
       return {
         subscribe: (observer) => {
           let next = observer.call ? observer : observer.next.bind(observer);
-          return Identity(this, next);
+          let identity = Identity(this, next);
+          next(identity);
+          return identity;
         },
         [SymbolObservable]() {
           return this;

--- a/tests/identity.test.js
+++ b/tests/identity.test.js
@@ -125,12 +125,8 @@ describe('Identity', () => {
       next = first.completed.set(true);
     });
 
-    it('returns the same id in the event that the state is the same', function() {
-      expect(next).toBe(store);
-    });
-
-    it('does not invoke the idenity function after the initial invocation', function() {
-      expect(calls).toEqual(1);
+    it('does not invoke the idenity function on initial invocation', function() {
+      expect(calls).toEqual(0);
     });
   });
 


### PR DESCRIPTION
Our observable integration predates Identity/Store implementation. When the Identity was implemented, we assumed that it follows the same logic as Observable integration. In reality, this proven to be untrue and pretty awkward in certain cases. 

For example, when hooking up the Identity in React components, it's desirable to setup the observer in the constructor. This caused an error to be logged into the console because setState was called before the component was mounted. 

```jsx
import { Component } from 'react';
import { Store, create } from 'microstates';

export default class extends Component {
  state = {
    $: Store(create(Number, 42), $ => this.setState({ $ }))
  }

  render() {
    return this.props.children(this.state.$);
  }
}
``` 

To prevent this problem, I had to introduce isMounted state which had to be checked before calling the setState. This is unnecessary work. This PR changes the Identity to not call the observer on instantiation. However, Observable integration will continue to stream the first state when a subscription is created. 