### PR TITLE
Fix a small code typo in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ When you're working with an array microstate, the shape of the Microstate is det
 ```js
 let blog2 = blog.posts.push({ id: 3, title: "It is only getter better" });
 
-for (let post of blog.posts) {
+for (let post of blog2.posts) {
   console.log(post);
 }
 


### PR DESCRIPTION
I’m new to microstates and was just reading over the readme. I _think_ there is a small bug in the Array Microstates example.

The example creates a new `blog2` after immutably ‘pushing’ onto `blog.posts` but then logs out the values of `blog.posts` which wouldn’t have the newly pushed on value since `blog.posts` is immutable. I think the example should be logging out the new `blog2.posts`.