### PR TITLE
Run coveralls once on Node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ jobs:
   include:
     - stage: Coverage Report
       node_js: "10"
-      install: 
-        - yarn global add coveralls
-        - yarn
       script: yarn lint && yarn coverage && yarn coveralls
 
 # Allow Travis tests to run in containers.

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ jobs:
   include:
     - stage: Coverage Report
       node_js: "10"
-      install: yarn global add coveralls
+      install: 
+        - yarn global add coveralls
+        - yarn
       script: yarn lint && yarn coverage && yarn coveralls
 
 # Allow Travis tests to run in containers.

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
   include:
     - stage: Coverage Report
       node_js: "10"
-      install: yarn global coveralls
+      install: yarn global add coveralls
       script: yarn lint && yarn coverage && yarn coveralls
 
 # Allow Travis tests to run in containers.

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ jobs:
   include:
     - stage: Coverage Report
       node_js: "10"
+      install: yarn global coveralls
       script: yarn lint && yarn coverage && yarn coveralls
 
 # Allow Travis tests to run in containers.

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,12 @@ node_js:
   - "8"
   - "6"
 
-after_success:
-  - yarn lint
-  - yarn coverage
-  - yarn coveralls
+script: echo "Running tests against $(node -v) ..."
+
+include:
+    - stage: coveralls
+      node_js: "10"
+      script: yarn lint && yarn coverage && yarn coveralls
 
 # Allow Travis tests to run in containers.
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ node_js:
 
 script: echo "Running tests against $(node -v) ..."
 
-include:
-    - stage: coveralls
+jobs:
+  include:
+    - stage: Coverage Report
       node_js: "10"
       script: yarn lint && yarn coverage && yarn coveralls
 

--- a/package.json
+++ b/package.json
@@ -52,12 +52,11 @@
     "rollup-plugin-babel": "4.0.0-beta.7",
     "rollup-plugin-filesize": "4.0.1",
     "rollup-plugin-node-resolve": "3.3.0",
+    "nyc": "13.1.0",
     "rxjs": "^6.2.1"
   },
   "dependencies": {
-    "coveralls": "3.0.2",
     "funcadelic": "^0.5.0",
-    "nyc": "13.1.0",
     "symbol-observable": "^1.2.0"
   },
   "nyc": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "babel-eslint": "^10.0.1",
     "benchmark": "^2.1.4",
     "cli-table": "^0.3.1",
+    "coveralls": "3.0.2",
     "eslint": "^5.7.0",
     "eslint-plugin-prefer-let": "^1.0.1",
     "expect": "^23.4.0",

--- a/tests/identity.test.js
+++ b/tests/identity.test.js
@@ -121,7 +121,7 @@ describe('Identity', () => {
         return x;
       });
       let [ first ] = store.todos;
-      next = first.completed.set(true);
+      first.completed.set(true);
     });
 
     it('does not invoke the idenity function on initial invocation', function() {

--- a/tests/identity.test.js
+++ b/tests/identity.test.js
@@ -114,7 +114,6 @@ describe('Identity', () => {
   describe('idempotency', function() {
     let calls;
     let store;
-    let next;
     beforeEach(function() {
       calls = 0;
       store = Identity(microstate, x => {


### PR DESCRIPTION
Our current setup is causing a lot of message from coveralls to be posted to PRs. 

## Before
<img width="856" alt="screen shot 2018-10-31 at 10 05 27 am" src="https://user-images.githubusercontent.com/74687/47793431-a305d700-dcf4-11e8-8309-2ff266e640ec.png">

## After

<img width="933" alt="image" src="https://user-images.githubusercontent.com/74687/47797970-caad6d00-dcfd-11e8-91d8-a86973ff2839.png">

This PR will change the setup to only run code coverage once on Node 10 instead of every version of Node. It also fixed linting because it doesn't look like lint failures was failing build before.