### PR TITLE
Store should allow destructuring microstates

### DIFF
--- a/src/identity.js
+++ b/src/identity.js
@@ -72,8 +72,7 @@ export default function Identity(microstate, observe = x => x) {
         let microstate = path.reduce((microstate, key) => {
           if (isArrayType(microstate)) {
             let value = valueOf(microstate)[key];
-            var mounted = mount(microstate, create(microstate.constructor.T, value), key);
-            return mounted
+            return mount(microstate, create(microstate.constructor.T, value), key);
           } else {
             return microstate[key];
           }

--- a/src/types/array.js
+++ b/src/types/array.js
@@ -4,8 +4,17 @@ import { Profunctor, promap, mount, valueOf } from '../meta';
 import { create } from '../microstates';
 import parameterized from '../parameterized';
 
+
+const ARRAY_TYPE = Symbol('ArrayType');
+
+export function isArrayType(microstate) {
+  return microstate.constructor && microstate.constructor[ARRAY_TYPE];
+}
+
 export default parameterized(T => class ArrayType {
   static T = T;
+  static get [ARRAY_TYPE]()  { return true; }
+
   static get name() {
     return `Array<${T.name}>`;
   }

--- a/tests/identity.test.js
+++ b/tests/identity.test.js
@@ -170,4 +170,31 @@ describe('Identity', () => {
       });
     });
   });
+
+  describe('identity support of type reuse', () => {
+    class Person {
+      name = String;
+      father = Person;
+      mother = Person;
+    }
+
+    it('it keeps both branches', () => {
+      let s = Identity(create(Person), next => (s = next));
+      let { name, father, mother } = s;
+
+      name.set('Bart');
+      father.name.set('Homer');
+      mother.name.set('Marge');
+
+      expect({
+        name: s.name.state,
+        father: { name: s.father.name.state },
+        mother: { name: s.mother.name.state }
+      }).toEqual({
+        name: 'Bart',
+        father: { name: 'Homer' },
+        mother: { name: 'Marge' }
+      });
+    });
+  });
 });


### PR DESCRIPTION
Previous to the move to femtostates refactor, an Id stored a reference to a Type and a path. In effect, a pointer into the "current" microstate. When performing a transition, we looked up the corresponding microstate on which we want to make the transition,starting at the root.

In this way, the microstates could vary freely, but the ids would remain stable.

With the move to femtostates, there was no `At` lens implementation for a microstate, and especially Array objects, so there was no way to do a `view` on a microstates from the top level down to the location where the transition was happening. So we opted for a pathmap which kept amapping of the Id to its microstate that was updated every time a path changed.

This was a fatally flawed approach since logically _every_ microstate in an entire tree changes its value on _every_ transition. Because microstates were stored at their ids location only when that id was navigated to, we were seeing all destructured references becoming stale on every transition.

This workaround re-introduces the approach of looking up the corresponding microstate from the root of the tree with every transition. It's a bit hacky because there is no `At` implementation for array microstate, so we have to do what _would_ happen if we did.

This is a proof of concept for the issue, but a more elegant solution exists if we re-introduce polymorphic lenses. Then, we can have a conatiner implementation for array microstate, and so we can lookup substates using a generic lens implementation.