### PR TITLE
Added remove transition to ArrayType

### DIFF
--- a/src/types/array.js
+++ b/src/types/array.js
@@ -76,6 +76,10 @@ export default parameterized(T => class ArrayType {
     }, list);
   }
 
+  remove(item) {
+    return this.filter(s => valueOf(s) !== valueOf(item));
+  }
+
   clear() {
     return [];
   }

--- a/tests/types/array.test.js
+++ b/tests/types/array.test.js
@@ -410,4 +410,24 @@ describe("ArrayType", function() {
       });
     });
   });
+
+  describe('remove', () => {
+    let array;
+    beforeEach(() => {
+      array = create([], ['a', 'b', 'c']);
+    });
+
+    it('allows to remove an element', () => {
+      let [a, b, c] = array;
+      let removed = array.remove(b);
+      let [a2, c2] = removed;
+      expect(removed.length).toBe(2);
+      expect(valueOf(a)).toBe(valueOf(a2));
+      expect(valueOf(c)).toBe(valueOf(c2));
+    });
+
+    it('returns same array when item is not found', () => {
+      expect(array.remove(null)).toBe(array);
+    });
+  });
 });


### PR DESCRIPTION
This PR introduces a `remove` transition to ArrayType microstates to make it easier to "remove" elements from an array. It's using the filter transition which ensures that the same microstate is returned when there is a no-op operation.

Closes #275 