### PR TITLE
Added object iterator to allow using ObjectType with queries

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -14,6 +14,17 @@ export function reduce(iterable, fn, initial) {
   return query(iterable).reduce(fn, initial);
 }
 
+export class Entry {
+  constructor(key, value) {
+    this.key = key;
+    this.value = value;
+  }
+
+  [Symbol.iterator]() {
+    return [this.value, this.key][Symbol.iterator]();
+  }
+}
+
 class Query {
   constructor(iterable) {
     if (typeof iterable[Symbol.iterator] === 'function') {

--- a/src/query.js
+++ b/src/query.js
@@ -14,17 +14,6 @@ export function reduce(iterable, fn, initial) {
   return query(iterable).reduce(fn, initial);
 }
 
-export class Entry {
-  constructor(key, value) {
-    this.key = key;
-    this.value = value;
-  }
-
-  [Symbol.iterator]() {
-    return [this.value, this.key][Symbol.iterator]();
-  }
-}
-
 class Query {
   constructor(iterable) {
     if (typeof iterable[Symbol.iterator] === 'function') {

--- a/src/types/object.js
+++ b/src/types/object.js
@@ -2,6 +2,7 @@ import { append, filter, map } from 'funcadelic';
 import parameterized from '../parameterized';
 import { mount, valueOf } from '../meta';
 import { create } from '../microstates';
+import { Entry } from '../query';
 
 export default parameterized(T => class ObjectType {
   static T = T;
@@ -52,7 +53,7 @@ export default parameterized(T => class ObjectType {
         let next = iterator.next();
         return {
           get done() { return next.done; },
-          get value() { return object[next.value]; }
+          get value() { return new Entry(next.value, object[next.value]) }
         };
       }
     };

--- a/src/types/object.js
+++ b/src/types/object.js
@@ -2,7 +2,6 @@ import { append, filter, map } from 'funcadelic';
 import parameterized from '../parameterized';
 import { mount, valueOf } from '../meta';
 import { create } from '../microstates';
-import { Entry } from '../query';
 
 export default parameterized(T => class ObjectType {
   static T = T;
@@ -59,3 +58,14 @@ export default parameterized(T => class ObjectType {
     };
   }
 });
+
+class Entry {
+  constructor(key, value) {
+    this.key = key;
+    this.value = value;
+  }
+
+  [Symbol.iterator]() {
+    return [this.value, this.key][Symbol.iterator]();
+  }
+}

--- a/src/types/object.js
+++ b/src/types/object.js
@@ -43,4 +43,18 @@ export default parameterized(T => class ObjectType {
   filter(fn) {
     return filter(({ key, value }) => valueOf(fn(create(T, value), key)), valueOf(this));
   }
+
+  [Symbol.iterator]() {
+    let object = this;
+    let iterator = Object.keys(valueOf(this))[Symbol.iterator]();
+    return {
+      next() {
+        let next = iterator.next();
+        return {
+          get done() { return next.done; },
+          get value() { return object[next.value]; }
+        };
+      }
+    };
+  }
 });

--- a/src/types/object.js
+++ b/src/types/object.js
@@ -53,7 +53,7 @@ export default parameterized(T => class ObjectType {
         let next = iterator.next();
         return {
           get done() { return next.done; },
-          get value() { return new Entry(next.value, object[next.value]) }
+          get value() { return new Entry(next.value, object[next.value]); }
         };
       }
     };

--- a/tests/types/object.test.js
+++ b/tests/types/object.test.js
@@ -3,6 +3,7 @@ import expect from 'expect';
 import { create } from '../../src/microstates';
 import { valueOf } from '../../src/meta';
 import { ObjectType } from '../../src/types';
+import { map } from '../../src/query';
 
 describe('created without value', () => {
   class Thing {}
@@ -223,6 +224,35 @@ describe("map/filter/reduce", () => {
       expect(filtered["a"]).toBeDefined();
       expect(filtered["b"]).not.toBeDefined();
       expect(filtered["c"]).toBeDefined();
+    });
+  });
+
+  describe('iterable', () => {
+    let obj, calls;
+    beforeEach(() => {
+      obj = create(Object, { a: 'A', b: 'B', c: 'C'});
+      calls = [];
+    });
+
+    it('supports for of', () => {
+      for (let o of obj) {
+        calls.push(o);
+      }
+
+      expect(calls.length).toBe(3);
+      expect(valueOf(calls[0])).toBe('A');
+      expect(valueOf(calls[1])).toBe('B');
+      expect(valueOf(calls[2])).toBe('C');
+    });
+
+    it('allows to map object', () => {
+      for (let o of map(obj, o => `${o.state}!!!`)) {
+        calls.push(o);
+      }
+      expect(calls.length).toBe(3);
+      expect(valueOf(calls[0])).toBe('A!!!');
+      expect(valueOf(calls[1])).toBe('B!!!');
+      expect(valueOf(calls[2])).toBe('C!!!');
     });
   });
 });

--- a/tests/types/object.test.js
+++ b/tests/types/object.test.js
@@ -234,25 +234,36 @@ describe("map/filter/reduce", () => {
       calls = [];
     });
 
-    it('supports for of', () => {
-      for (let o of obj) {
-        calls.push(o);
+    it('supports for of and destructure as object', () => {
+      for (let { value, key } of obj) {
+        calls.push({ key, value: value.state });
       }
 
       expect(calls.length).toBe(3);
-      expect(valueOf(calls[0])).toBe('A');
-      expect(valueOf(calls[1])).toBe('B');
-      expect(valueOf(calls[2])).toBe('C');
+      expect(valueOf(calls[0])).toEqual({key: 'a', value: 'A'});
+      expect(valueOf(calls[1])).toEqual({key: 'b', value: 'B'});
+      expect(valueOf(calls[2])).toEqual({key: 'c', value: 'C'});
+    });
+
+    it('supports for of and destructure as array', () => {
+      for (let [ value, key ] of obj) {
+        calls.push({ key, value: value.state });
+      }
+
+      expect(calls.length).toBe(3);
+      expect(valueOf(calls[0])).toEqual({key: 'a', value: 'A'});
+      expect(valueOf(calls[1])).toEqual({key: 'b', value: 'B'});
+      expect(valueOf(calls[2])).toEqual({key: 'c', value: 'C'});
     });
 
     it('allows to map object', () => {
-      for (let o of map(obj, o => `${o.state}!!!`)) {
+      for (let o of map(obj, ({ key, value }) => ({ key, value: value.state }))) {
         calls.push(o);
       }
       expect(calls.length).toBe(3);
-      expect(valueOf(calls[0])).toBe('A!!!');
-      expect(valueOf(calls[1])).toBe('B!!!');
-      expect(valueOf(calls[2])).toBe('C!!!');
+      expect(valueOf(calls[0])).toMatchObject({key: 'a', value: 'A'});
+      expect(valueOf(calls[1])).toMatchObject({key: 'b', value: 'B'});
+      expect(valueOf(calls[2])).toMatchObject({key: 'c', value: 'C'});
     });
   });
 });


### PR DESCRIPTION
This PR introduces `Symbol.iterator` for ObjectType. This makes it possible to use object microstates with `for (let obj of microstates)` syntax, which also provides support for Queries to map, filter and reduce objects.

The iterator yields entry objects which allow the key/value to be restructured as objects `for (let { key, value } of microstates)` or arrays `for (let [value key] of microstates)`.

Closes #224 