### PR TITLE
No special case for the `set` transition.

### DIFF
--- a/src/microstates.js
+++ b/src/microstates.js
@@ -1,4 +1,4 @@
-import { stable, map } from 'funcadelic';
+import { append, stable, map } from 'funcadelic';
 import { set } from './lens';
 import { Meta, mount, metaOf, valueOf, sourceOf } from './meta';
 import { methodsOf } from './reflection';
@@ -40,28 +40,25 @@ const MicrostateType = stable(function MicrostateType(Type) {
 
       Object.defineProperty(this, Meta.symbol, { enumerable: false, configurable: true, value: new Meta(this, valueOf(value))});
     }
-
-    set(object) {
-      let meta = metaOf(this);
-      let previous = valueOf(meta.root);
-      let next = set(meta.lens, valueOf(object), previous);
-      if (meta.path.length === 0 && metaOf(object) != null) {
-        return object;
-      } if (next === previous) {
-        return meta.root;
-      } else {
-        return create(meta.root.constructor, next);
-      }
-    }
   };
+
   Object.defineProperties(Microstate.prototype, map((descriptor) => {
     return {
       value(...args) {
         let result = descriptor.value.apply(sourceOf(this), args);
-        return this.set(result);
+        let meta = metaOf(this);
+        let previous = valueOf(meta.root);
+        let next = set(meta.lens, valueOf(result), previous);
+        if (meta.path.length === 0 && metaOf(result) != null) {
+          return result;
+        } if (next === previous) {
+          return meta.root;
+        } else {
+          return create(meta.root.constructor, next);
+        }
       }
     };
-  }, methodsOf(Type)));
+  }, append({ set: { value: x => x } }, methodsOf(Type))));
   return Microstate;
 });
 

--- a/src/reflection.js
+++ b/src/reflection.js
@@ -2,6 +2,6 @@ import { filter } from 'funcadelic';
 
 export function methodsOf(Type) {
   return filter(({ key: name, value: desc }) => {
-    return name !== 'constructor' && name !== 'set' && typeof name === 'string' && typeof desc.value === 'function';
+    return name !== 'constructor' && typeof name === 'string' && typeof desc.value === 'function';
   }, Object.getOwnPropertyDescriptors(Type.prototype));
 }


### PR DESCRIPTION
Microstate transitions are like a transaction. You start with a microstate, and what is returned is the next version of that microstate.

However, this transaction was being spread over two methods: the actual transition invocation and the `set` method. In other words, the transition method was just called, and then the "work" was happening in `set`.

As we move the codebase to have more interesting outcomes inside a single transition like being able to transition to different parts of the store, we'll need to be able to reason about what exactly a state transition is in a single place.

This change places all of the transition logic in a single location: the transition method, and `set` becomes just another transition that isn't at all special except for the fact that a default implemenation (the identity function) is provided for it without you having to specify it in the class definition.

Having no special transitions will give us the power to make changes to transition semantics without having to worry about corner cases.