### PR TITLE
Gather transitions from prototype chain

### DIFF
--- a/src/reflection.js
+++ b/src/reflection.js
@@ -1,7 +1,24 @@
 import { filter } from 'funcadelic';
 
+const { getPrototypeOf, getOwnPropertyDescriptors, assign } = Object;
+
 export function methodsOf(Type) {
   return filter(({ key: name, value: desc }) => {
     return name !== 'constructor' && typeof name === 'string' && typeof desc.value === 'function';
-  }, Object.getOwnPropertyDescriptors(Type.prototype));
+  }, getAllPropertyDescriptors(Type.prototype));
+}
+
+/**
+ * As opposed to `getOwnPropertyDescriptors` which only gets the
+ * descriptors on a single object, `getAllPropertydescriptors` walks
+ * the entire prototype chain starting at `prototype` and gather all
+ * descriptors that are accessible to this object.
+ */
+function getAllPropertyDescriptors(object) {
+  if (object === Object.prototype) {
+    return {};
+  } else {
+    let prototype = getPrototypeOf(object);
+    return assign(getAllPropertyDescriptors(prototype), getOwnPropertyDescriptors(object));
+  }
 }

--- a/tests/identity.test.js
+++ b/tests/identity.test.js
@@ -209,4 +209,25 @@ describe('Identity', () => {
       expect(i.name.state).toBe('Taras!!!');
     });
   });
+
+  describe('supports destructuring inherited transitions', () => {
+    class Parent {
+      a = String;
+      setA(str) {
+        return this.a.set(str);
+      }
+    }
+    class Child extends Parent {}
+
+    let i, setA;
+    beforeEach(() => {
+      i = Identity(create(Child), next => i = next);
+      setA = i.setA;
+    });
+
+    it('allows invoking a transition', () => {
+      setA('taras');
+      expect(i.a.state).toEqual('taras');
+    });
+  });
 });


### PR DESCRIPTION
When a transition is inherited from the parent, the transition definition resides on the parent's prototype. This resulted in closures not being created around parent's transitions because `methodOf` function that was used to gather transitions was only looking on the class's prototype. 

This PR introduces `getPrototypeDescriptors` function that gathers prototypes by recursively walking the prototype chain. `methodOf` consumes this function to ensure that all transitions are included when creating closures for transitions.

Closes #287 
Related https://github.com/microstates/ember/issues/78