### PR TITLE
Prepare v0.12.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.12.4] - 2018-12-12
 
+### Fixed
+
 - Add explicit Profunctor class name to prevent the class name from being stripped by Uglifyjs https://github.com/microstates/microstates.js/pull/303
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.12.4] - 2018-12-12
+
+- Add explicit Profunctor class name to prevent the class name from being stripped by Uglifyjs https://github.com/microstates/microstates.js/pull/303
+
+### Fixed
+
+- Gather all transitions from the prototype chain https://github.com/microstates/microstates.js/pull/290
+
 ## [0.12.3] - 2018-12-12
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microstates",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Composable State Primitives for JavaScript",
   "keywords": [
     "lens",


### PR DESCRIPTION
### Fixed

## [0.12.4] - 2018-12-12

- Add explicit Profunctor class name to prevent the class name from being stripped by Uglifyjs https://github.com/microstates/microstates.js/pull/303