### PR TITLE
Fix minor README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,7 +645,7 @@ Microstates does not do any special state resolution. You explicitly declare wha
 class LightMachine {
   color = String;
 
-  initialize({ color: 'green' } = {}) {
+  initialize({ color = 'green' } = {}) {
     return this.color.set(color);
   }
 


### PR DESCRIPTION
I'm not a user, yet, of this library, but it presents a nice concept for handling composition of state.

Just saw a minor syntax error while reading through (:

Nice Work!