### PR TITLE
Don't allow microstates to become part of Array values.

### DIFF
--- a/src/types/array.js
+++ b/src/types/array.js
@@ -34,7 +34,7 @@ export default parameterized(T => class ArrayType {
   }
 
   push(value) {
-    return [...valueOf(this), value];
+    return [...valueOf(this), valueOf(value)];
   }
 
   pop() {
@@ -47,7 +47,7 @@ export default parameterized(T => class ArrayType {
   }
 
   unshift(value) {
-    return [value, ...valueOf(this)];
+    return [valueOf(value), ...valueOf(this)];
   }
 
   slice(begin, end) {

--- a/tests/types/array.test.js
+++ b/tests/types/array.test.js
@@ -34,6 +34,18 @@ describe("ArrayType", function() {
           expect(valueOf(again)).toEqual(["a", "b", "c", "d", "e"]);
         });
       });
+
+      describe('another microstate', function() {
+        let again;
+        beforeEach(function() {
+          again = pushed.push(create(String, "e"));
+        });
+
+        it('uses the value of the microstate, not the microstate itself', function() {
+          expect(valueOf(again)).toEqual(["a", "b", "c", "d", "e"]);
+        });
+      });
+
     });
 
     describe("pop", () => {
@@ -315,6 +327,19 @@ describe("ArrayType", function() {
             expect(second.content.state).toBe('Herro!!!');
           });
         });
+
+        describe('a microstate', () => {
+          beforeEach(()=> {
+            unshifted = dataset.records.unshift(create(null, { content: "Hello World!" }));
+          });
+
+
+          it('uses the value of the microstate and not the microstate itself.', function() {
+            let [ first ] = valueOf(unshifted.records);
+            expect(first).toEqual({ content: 'Hello World!'});
+          });
+        });
+
       });
 
       describe('filter', () => {


### PR DESCRIPTION
With Union types (which are in the works) a very common use-case is to pass in a microstate union in a transition on a parent microstate:

```js
uploader.uploads.push(Upload.New.create({ file }))
````

What we really want is the _value_ of the upload, not the actual microstate upload itself. That means that whenever we want to include a value into a container object like an array, then we need to unwrap the microstate before putting it into the value. This ensures that the microstate itself can always be re-hydrated from its simple POJO values.

This unwraps the value before putting it into an array value for both push and pop. Any future array method that creates a record, like insert for example, should also be careful only to include simple values.