### PR TITLE
[WIP] - Represent every microstate internally with an object.

### DIFF
--- a/src/identity.js
+++ b/src/identity.js
@@ -102,6 +102,6 @@ function equals(id, other) {
   if (other == null) {
     return false;
   } else {
-    return other.constructor.Type === id.constructor.Type && valueOf(id) === valueOf(other);
+    return other.constructor.Type === id.constructor.Type && valueOf(id).valueOf() === valueOf(other).valueOf();
   }
 }

--- a/src/lens.js
+++ b/src/lens.js
@@ -63,7 +63,7 @@ export function At(property, container = {}) {
   let get = context => context != null ? context[property] : undefined;
   let set = (part, whole) => {
     let context = whole == null ? (Array.isArray(container) ? [] : {}) : whole;
-    if (part === context[property]) {
+    if (primitiveOf(part) === primitiveOf(context[property])) {
       return context;
     } else if (Array.isArray(context)) {
       let clone = context.slice();
@@ -79,4 +79,9 @@ export function At(property, container = {}) {
 
 export function Path(path = []) {
   return path.reduce((lens, key) => compose(lens, At(key)), transparent);
+}
+
+
+function primitiveOf(object) {
+  return object == null ? object : object.valueOf();
 }

--- a/src/literal.js
+++ b/src/literal.js
@@ -2,10 +2,10 @@ import { create } from './microstates';
 
 class Literal {
   initialize(value) {
+    value = value.valueOf();
     if (value == null) {
       return this;
     }
-    value = value.valueOf();
     switch (typeof value) {
       case "number":
         return create(Number, value);

--- a/src/meta.js
+++ b/src/meta.js
@@ -1,4 +1,5 @@
 import { type, append } from 'funcadelic';
+import objectOf from './object-of';
 import { At, compose, transparent, over, view } from './lens';
 
 export class Meta {
@@ -26,7 +27,7 @@ export function metaOf(object) {
 
 export function valueOf(object) {
   let meta = metaOf(object);
-  return meta != null ? meta.value : object;
+  return objectOf(meta != null ? meta.value : object);
 }
 
 export function pathOf(object) {

--- a/src/microstates.js
+++ b/src/microstates.js
@@ -7,7 +7,8 @@ import Any from './types/any';
 import CachedProperty from './cached-property';
 import Observable from './observable';
 
-export function create(InputType = Any, value) {
+export function create(InputType = Any, initial) {
+  let value = valueOf(initial);
   let { Type } = dsl.expand(InputType);
   let Microstate = MicrostateType(Type);
   let microstate = new Microstate(value);
@@ -58,9 +59,17 @@ const MicrostateType = stable(function MicrostateType(Type) {
         }
       }
     };
-  }, append({ set: { value: x => x } }, methodsOf(Type))));
+  }, append({ set: { value: setValue } }, methodsOf(Type))));
   return Microstate;
 });
+
+function setValue(value) {
+  if (valueOf(value).valueOf() === valueOf(this).valueOf()) {
+    return this;
+  } else {
+    return valueOf(value);
+  }
+}
 
 function expandProperty(property) {
   let meta = metaOf(property);

--- a/src/object-of.js
+++ b/src/object-of.js
@@ -3,13 +3,14 @@ export default function objectOf(value) {
     return new Null();
   } else if (typeof value === 'undefined') {
     return new Undefined();
-  } else {
+  }  else {
     return Object(value);
   }
 }
 
 function Constant(value) {
   return class {
+    toString() { return ''; }
     valueOf() { return value; }
   };
 }

--- a/src/object-of.js
+++ b/src/object-of.js
@@ -1,0 +1,18 @@
+export default function objectOf(value) {
+  if (value === null) {
+    return new Null();
+  } else if (typeof value === 'undefined') {
+    return new Undefined();
+  } else {
+    return Object(value);
+  }
+}
+
+function Constant(value) {
+  return class {
+    valueOf() { return value; }
+  };
+}
+
+class Null extends Constant(null) {}
+class Undefined extends Constant(undefined) {}

--- a/src/types/array.js
+++ b/src/types/array.js
@@ -24,7 +24,7 @@ export default parameterized(T => class ArrayType {
   }
 
   initialize(value) {
-    if (value == null) {
+    if (value.valueOf() === undefined) {
       return [];
     } else if (Array.isArray(value)) {
       return value;
@@ -77,7 +77,7 @@ export default parameterized(T => class ArrayType {
   }
 
   remove(item) {
-    return this.filter(s => valueOf(s) !== valueOf(item));
+    return this.filter(s => valueOf(s).valueOf() !== valueOf(item).valueOf());
   }
 
   clear() {

--- a/src/types/boolean.js
+++ b/src/types/boolean.js
@@ -4,8 +4,13 @@ export default class BooleanType extends Primtive {
   static name = "Boolean";
 
   initialize(value) {
-    return !!value;
+    if (value instanceof Boolean) {
+      return value;
+    } else {
+      return new Boolean(Boolean(value.valueOf()));
+    }
   }
+
   toggle() {
     return !this.state;
   }

--- a/src/types/number.js
+++ b/src/types/number.js
@@ -4,12 +4,12 @@ export default class NumberType extends Primitive {
   static name = "Number";
 
   initialize(value) {
-    if (value == null) {
-      return 0;
-    } else if (isNaN(value)) {
-      return this;
+    if (value instanceof Number) {
+      return value;
+    } else if (value.valueOf() === undefined) {
+      return new Number(0);
     } else {
-      return Number(value);
+      return new Number(Number(value.valueOf()));
     }
   }
   increment(step = 1) {

--- a/src/types/object.js
+++ b/src/types/object.js
@@ -23,7 +23,7 @@ export default parameterized(T => class ObjectType {
   }
 
   initialize(value) {
-    return value == null ? {} : this;
+    return value.valueOf() == null ? {} : this;
   }
 
   assign(attrs) {
@@ -43,7 +43,7 @@ export default parameterized(T => class ObjectType {
   }
 
   filter(fn) {
-    return filter(({ key, value }) => valueOf(fn(create(T, value), key)), valueOf(this));
+    return filter(({ key, value }) => fn(create(T, value), key), valueOf(this));
   }
 
   [Symbol.iterator]() {

--- a/src/types/primitive.js
+++ b/src/types/primitive.js
@@ -2,6 +2,6 @@ import { valueOf } from '../meta';
 
 export default class Primitive {
   get state() {
-    return valueOf(this);
+    return valueOf(this).valueOf();
   }
 }

--- a/src/types/string.js
+++ b/src/types/string.js
@@ -4,7 +4,11 @@ export default class StringType extends Primitive {
   static name = "String";
 
   initialize(value) {
-    return String(value == null ? '' : value);
+    if (value instanceof String) {
+      return value;
+    } else {
+      return new String(value);
+    }
   }
 
   concat(value) {

--- a/tests/examples/authentication.test.js
+++ b/tests/examples/authentication.test.js
@@ -4,7 +4,7 @@ import { create } from '../../src/microstates';
 
 class AnonymousSession {
   initialize(session) {
-    if (session) {
+    if (session.valueOf()) {
       return this.authenticate(session);
     }
     return this;

--- a/tests/identity.test.js
+++ b/tests/identity.test.js
@@ -21,36 +21,36 @@ describe('Identity', () => {
         .todos.push({ title: "profit $$"});
       id = Identity(microstate);
     });
-  
+
     it('is derived from its source object', function() {
       expect(id).toBeInstanceOf(TodoMVC);
     });
-  
+
     it('has the same shape as the initial state.', function() {
       expect(id.completeAll).toBeInstanceOf(Function);
       expect(id.todos).toHaveLength(4);
-  
+
       let [ first ] = id.todos;
       let [ $first ] = microstate.todos;
       expect(first).toBeInstanceOf(Todo);
       expect(valueOf(first)).toBe(valueOf($first));
     });
-  
+
     describe('invoking a transition', function() {
       let next, third;
       beforeEach(function() {
         [ ,, third ] = id.todos;
-  
+
         next = third.completed.set(true);
       });
-  
+
       it('transitions the nodes which did change', function() {
         expect(next).not.toBe(id);
         expect(next.todos).not.toBe(id.todos);
         let [ ,, $third] = next.todos;
         expect($third).not.toBe(third);
       });
-  
+
       it('maintains the === identity of the nodes which did not change', function() {
         let [first, second, third, fourth] = id.todos;
         let [$first, $second, $third, $fourth] = next.todos;
@@ -60,14 +60,14 @@ describe('Identity', () => {
         expect($fourth).toBe(fourth);
       });
     });
-  
+
     describe('implicit method binding', function() {
       let next;
       beforeEach(function() {
         let shift = id.todos.shift;
         next = shift();
       });
-  
+
       it('still completes the transition', function() {
         expect(valueOf(next)).toEqual({
           todos: [{
@@ -80,38 +80,38 @@ describe('Identity', () => {
         });
       });
     });
-  
+
     describe('transition stability', function() {
       let next;
       beforeEach(function() {
         let [ first ] = id.todos;
         next = first.completed.set(false);
       });
-  
+
       it('uses the same function for each location in the graph, even for different instances', function() {
         expect(next).not.toBe(id);
         expect(next.set).toBe(id.set);
-  
+
         let [ first ] = id.todos;
         let [ $first ] = next.todos;
-  
+
         expect($first.push).toBe(first.push);
         expect($first.completed.toggle).toBe(first.completed.toggle);
       });
     });
-  
+
     describe('the identity callback function', function() {
       let store;
       beforeEach(function() {
         store = Identity(microstate, () => undefined);
       });
-  
+
       it('ignores the return value of the callback function when determining the value of the store', function() {
         expect(store).toBeDefined();
         expect(store).toBeInstanceOf(TodoMVC);
       });
     });
-  
+
     describe('idempotency', function() {
       let calls;
       let store;
@@ -124,26 +124,26 @@ describe('Identity', () => {
         let [ first ] = store.todos;
         first.completed.set(true);
       });
-  
+
       it('does not invoke the idenity function on initial invocation', function() {
         expect(calls).toEqual(0);
       });
     });
-  
+
     describe('identity of queries', function() {
       it('traverses queries and includes the microstates within them', function() {
         expect(id.completed).toBeDefined();
         let [ firstCompleted ] = id.completed;
         expect(firstCompleted).toBeInstanceOf(Todo);
       });
-  
+
       describe('the effect of transitions on query identities', () => {
         let next;
         beforeEach(function() {
           let [ first ] = id.completed;
           next = first.title.set('Take out the milk');
         });
-  
+
         it('updates those queries which contain changed objects, but not ids *within* the query that remained the same', () => {
           let [first, second] = id.completed;
           let [$first, $second] = next.completed;
@@ -151,7 +151,7 @@ describe('Identity', () => {
           expect($first).not.toBe(first);
           expect($second).toBe(second);
         });
-  
+
         it.skip('maintains the === identity of those queries which did not change', function() {
           let [first, second] = id.active;
           let [$first, $second] = next.active;
@@ -159,7 +159,7 @@ describe('Identity', () => {
           expect($second).toBe(second);
           expect(next.active).toBe(id.active);
         });
-  
+
         it('maintains the === identity of the same node that appears at different spots in the tree', () => {
           let [ first ] = id.todos;
           let [ firstCompleted ] = id.completed;
@@ -177,6 +177,13 @@ describe('Identity', () => {
       name = String;
       father = Person;
       mother = Person;
+      initialize(value) {
+        if (value.valueOf() == null) {
+          return {};
+        } else {
+          return this;
+        }
+      }
     }
 
     it('it keeps both branches', () => {
@@ -217,7 +224,15 @@ describe('Identity', () => {
         return this.a.set(str);
       }
     }
-    class Child extends Parent {}
+    class Child extends Parent {
+      initialize(value) {
+        if (value.valueOf() == null) {
+          return {};
+        } else {
+          return this;
+        }
+      }
+    }
 
     let i, setA;
     beforeEach(() => {

--- a/tests/initialization.test.js
+++ b/tests/initialization.test.js
@@ -77,7 +77,7 @@ describe('initialization', () => {
       name = String;
 
       initialize(props) {
-        if (!props) {
+        if (!props.valueOf()) {
           return create(Second, { name: "default" });
         }
         return this;

--- a/tests/lens.test.js
+++ b/tests/lens.test.js
@@ -22,4 +22,9 @@ describe('At', function() {
     let object = set(lens, "world", undefined);
     expect(set(lens, "world", object)).toBe(object);
   });
+
+  it('uses primitive values to compare if two things are equal', ()=> {
+    let initial = [{ hello: 'world' }];
+    expect(set(lens, new String('world'), initial)).toBe(initial);
+  });
 });

--- a/tests/literal.test.js
+++ b/tests/literal.test.js
@@ -21,7 +21,7 @@ describe('Literal Syntax', function() {
   });
 
   it('can create nulls', function() {
-    expect(valueOf(literal(null))).toEqual(null);
+    expect(valueOf(literal(null)).valueOf()).toEqual(null);
   });
 
   it('can create arrays', function() {

--- a/tests/object-of.test.js
+++ b/tests/object-of.test.js
@@ -1,0 +1,40 @@
+/* global describe, it */
+
+import expect from 'expect';
+
+import objectOf from '../src/object-of';
+
+describe('objectOf', ()=> {
+  describe('null', ()=> {
+    it('it converts null to an object', ()=> {
+      expect(typeof objectOf(null)).toBe('object');
+    });
+    it('has a valueOf() null', ()=> {
+      expect(objectOf(null).valueOf()).toBe(null);
+    });
+  });
+
+  describe('undefined', ()=> {
+    it('converts undefined into an object', ()=> {
+      expect(typeof objectOf(undefined)).toBe('object');
+    });
+    it('has a valueOf() undefined', ()=> {
+      expect(objectOf(undefined).valueOf()).toBe(undefined);
+    });
+  });
+
+  describe('primitives', ()=> {
+    it('converts into their corresponding box', ()=> {
+      expect(typeof objectOf(5)).toBe('object');
+      expect(objectOf(5)).toBeInstanceOf(Number);
+      expect(objectOf(5).valueOf()).toBe(5);
+    });
+  });
+
+  describe('everything else', ()=> {
+    it('leaves as-is', ()=> {
+      let object = {};
+      expect(objectOf(object)).toBe(object);
+    });
+  });
+});

--- a/tests/observable.test.js
+++ b/tests/observable.test.js
@@ -27,7 +27,7 @@ describe('rxjs interop', function() {
   });
 
   it('incremented 3 times', function() {
-    expect(valueOf(last)).toBe(45);
+    expect(valueOf(last)).toEqual(45);
   });
 });
 
@@ -126,7 +126,7 @@ describe('initialized microstate', () => {
     isOpen = create(class BooleanType {});
 
     initialize(value) {
-      if (!value) {
+      if (!value.valueOf()) {
         return create(Modal, { isOpen: true });
       }
       return this;

--- a/tests/parameterized.test.js
+++ b/tests/parameterized.test.js
@@ -146,7 +146,7 @@ describe("Parameterized Microstates: ", () => {
       expect(m).toBeInstanceOf(TodoList);
       expect(m.items).toHaveLength(2);
       let value = valueOf(m);
-      expect(value.items[0].isCompleted).toBe(true);
+      expect(value.items[0].isCompleted).toEqual(true);
 
       let [ first, second ] = m.items;
       expect(first).toBeInstanceOf(Item);

--- a/tests/todomvc.js
+++ b/tests/todomvc.js
@@ -20,6 +20,14 @@ export class TodoMVC {
     return filter(this.todos, todo => !todo.completed.state);
   }
 
+  initialize(value) {
+    if (value.valueOf() == null) {
+      return {};
+    } else {
+      return this;
+    }
+  }
+
   completeAll() {
     return this.todos.map(todo => todo.completed.set(true));
   }

--- a/tests/types/array.test.js
+++ b/tests/types/array.test.js
@@ -422,8 +422,8 @@ describe("ArrayType", function() {
       let removed = array.remove(b);
       let [a2, c2] = removed;
       expect(removed.length).toBe(2);
-      expect(valueOf(a)).toBe(valueOf(a2));
-      expect(valueOf(c)).toBe(valueOf(c2));
+      expect(valueOf(a).valueOf()).toBe(valueOf(a2).valueOf());
+      expect(valueOf(c).valueOf()).toBe(valueOf(c2).valueOf());
     });
 
     it('returns same array when item is not found', () => {

--- a/tests/types/number.test.js
+++ b/tests/types/number.test.js
@@ -56,7 +56,7 @@ describe("number", () => {
 
   describe("with a NaN value", () => {
     it("has state", () => {
-      expect(str.state).toBe('hello');
+      expect(str.state).toBe(NaN);
     });
   });
 });

--- a/tests/types/object.test.js
+++ b/tests/types/object.test.js
@@ -179,27 +179,31 @@ describe('put and delete', () => {
 
 describe("map/filter/reduce", () => {
   class Todo {
-    id = create(String);
-    completed = create(Boolean, false);
+    id = String;
+    completed = Boolean;
   }
 
-  let todosById = create(
-    { Todo },
-    {
-      a: {
-        id: "a",
-        completed: false
-      },
-      b: {
-        id: "b",
-        completed: true
-      },
-      c: {
-        id: "c",
-        completed: false
+  let todosById;
+
+  beforeEach(()=> {
+    todosById = create(
+      { Todo },
+      {
+        a: {
+          id: "a",
+          completed: false
+        },
+        b: {
+          id: "b",
+          completed: true
+        },
+        c: {
+          id: "c",
+          completed: false
+        }
       }
-    }
-  );
+    );
+  });
 
   describe("map", () => {
     let mapped;

--- a/tests/types/string.test.js
+++ b/tests/types/string.test.js
@@ -9,7 +9,7 @@ describe('string without value', () => {
   });
 
   it('has state', () => {
-    expect(string.state).toBe('');
+    expect(string.state).toEqual('');
   });
 
   describe('concat', () => {


### PR DESCRIPTION
JavaScript has the concept of "primitive" types and "object" types. Number literals like `5` and string literals like "five" are not actually objects even though they have object methods available to them. Unlike an object, they are _sealed and immutable_. You may not change, add, or remove any of their properties. 

The reason this is so, and why it's important to microstates, is that they do not create a separate identity for each usage of a primitive. No matter how it is computed, either as a literal, or derived from some other value, each value of a primitive is indistinguishable from another usage of that same value. So, for example, `2+3 === 5` will always be true since what is being compared with strict equality is the in-memory representation of the number five. Contrast this with object types where the in-memory representation is effectively a pointer to the actual object, so that address is what gives the object its exclusive identity. In other words, `new Number(5) === new Number(5)` is false because each object has a different address.

### Why is this a problem for microstates?

This presents a challenge because there's no convenient way to uniquely identify a microstate which is something that we have to do if we want to make the elements in a store stable. The low-level microstates are pure functions, and so each microstate represents a unique point in time, so we cannot use the reference to the microstate itself.

Currently, what we do is do a convoluted tree-mapping excercise where we use the triple of (Type, value, path) to uniquely identify a microstate.  But this has some drawbacks.

1. It's awkward and the functional mapping of the tree is difficult to understand. Contrast this with a simple map lookup that we could do with a unique value.
2. As a follow on to the above, the only way to "lookup" a stable microstate in the store is by walking to its path from the root. Using a unique object, we can store that information directly in a weakmap or even on the object itself.
3. The memory implications are unknown. Even with the current implementation, memory leaks of the stable proxy objects could be kept around for microstates that are no longer in the tree.

If on the other hand, every microstate value was an object, we could store the stable proxies in a weak map, so that they would be trivial to look up, and the lookup could be done without walking the microstate tree to the point where the proxy lived.

### Approach

This change attempts to enable just a weakmap based proxy system by ensuring that every value in the value tree of a microstate is represented by an object, not a value. When you call `create(Type, value)`, `value` will be "upgraded" to an appropriate object. Therefore inside microstate transitions you are _always_ dealing with an object. primitive strings become `String` objects, primitive numbers become `Number` objects, and `null` and `undefined` are upgraded to instances of the classes and `Undefined` respectively.

In other words:

```js
valueOf(create(Number, 5)) //=> Number { 5 }
valueOf(create(Number, 5)).valueOf() //=> 5 
valueOf(create(Any, null)) //=> Null { }
valueOf(create(Any, null)).valueOf() //=> null
```

### Concerns / Questions

- This slightly changes the meaning of `valueOf` even if the contract remains the same since it really isn't a thing that you can use for equality comparison anymore. For example, the `Array#filter` method had to be re-written as such:

```js
remove(item) {
    return this.filter(s => valueOf(s).valueOf() !== valueOf(item).valueOf());
  }
```

notice the `valueOf(x).valueOf()`. This is becomes much more prevalent such that it makes me think that we might need another helper like `stateOf(x)` that is equilavent to `valueOf(x).valueOf()`

- Since a microstate should never have anything but an object value, do we want to warn if initialize returns something other than that, or again, just silently upgrade it.

- Why allow `null` or `undefined` at all? Instead, it seems more valuable to have an "empty" function which returns the empty value, `{}` for Object, `[]` for Array, '' for String, and default of `{}` for everything else.

- *Red-hydrating*: Primitive wrappers like `Number` serialize via JSON to their primitive counterparts, which makes this change particularly low-impact. In other words, `JSON.stringify(new Number(5))` => `"5"`. But what do we do when we want to go in the other direction?

```js
create(ArrayType.of(Num), [1, 2, 3]))
```

We want to be able to create proxies out of this from the get-go, but how do we do it short of a full mapping of the Array into its `Number` object equivalents before it can be used? And how can we efficiently do this for the entire tree? Can it be done lazily? I don't know.
