### PR TITLE
Use abstract operation to access microstate children by key.

### DIFF
--- a/src/identity.js
+++ b/src/identity.js
@@ -1,8 +1,6 @@
 import { foldl } from 'funcadelic';
-import { promap, valueOf, pathOf, Meta, mount } from './meta';
+import { promap, valueOf, pathOf, Meta } from './meta';
 import { methodsOf } from './reflection';
-import { isArrayType } from './types/array';
-import { create } from './microstates';
 
 //function composition should probably not be part of lens :)
 import { At, view, Path, compose, set } from './lens';
@@ -65,22 +63,15 @@ export default function Identity(microstate, observe = x => x) {
 
     Object.assign(Id.prototype, foldl((methods, name) => {
       methods[name] = function(...args) {
-        let path = P;
-        let microstate = path.reduce((microstate, key) => {
-          if (isArrayType(microstate)) {
-            let value = valueOf(microstate)[key];
-            return mount(microstate, create(microstate.constructor.T, value), key);
-          } else {
-            return microstate[key];
-          }
-        }, current);
+        let microstate = view(Path(Id.path), current);
+
         let next = microstate[name](...args);
 
         if (next !== current) {
           tick(next);
           return this;
         } else {
-          return view(Path(path), pathmap);
+          return view(Path(Id.path), pathmap);
         }
       };
       return methods;

--- a/src/lens.js
+++ b/src/lens.js
@@ -1,5 +1,7 @@
 import { Functor, map, Semigroup } from 'funcadelic';
 
+import { childAt } from './tree';
+
 class Box {
   static get of() {
     return (...args) => new this(...args);
@@ -60,7 +62,7 @@ export function Lens(get, set) {
 export const transparent = Lens(x => x, y => y);
 
 export function At(property, container = {}) {
-  let get = context => context != null ? context[property] : undefined;
+  let get = context => context != null ? childAt(property, context) : undefined;
   let set = (part, whole) => {
     let context = whole == null ? (Array.isArray(container) ? [] : {}) : whole;
     if (part === context[property]) {

--- a/src/tree.js
+++ b/src/tree.js
@@ -1,0 +1,13 @@
+import { type } from 'funcadelic';
+
+export const Tree = type(class {
+  childAt(key, parent) {
+    if (parent[Tree.symbol]) {
+      return this(parent).childAt(key, parent);
+    } else {
+      return parent[key];
+    }
+  }
+});
+
+export const { childAt } = Tree.prototype;


### PR DESCRIPTION
An identity is a reference to a microstate that can change over time, but the actual Id object doesn't have a direct reference to the microstate it represents. Instead it holds the _path_ of the microstate and looks it up each time from the latest value that is contained in the identity. This process of looking up the corresponding microstate means navigating down each element of the path.

But this presents a problem. Due to the laziness of Arrays (and soon Objects) We can't use standard keyed access all the time because array microstates can only access their children via enumeration. In other words, normal JS property access doesn't work.

```js
let array = create([Number], [1,2,3]);
array[2] //=> undefined

let [one, two] = array;
one //=> Microstate<Number>;
```

We got around this before by putting in a special hack for arrays to check "hey, is this an array microstate? If so, let's give a separate treatment." Not only was this cumbersome, but we'll need to add yet another hack for `ObjectType`, and furthermore, it is incompatible with the changes that we need to put in place to make identities support union types.

This change adds a typeclass `Children` with a single method `childAt` which abstracts away the JS operation for property access. That way, if we have the path of an entity, we can resolve it even if it's comprised of many different types of objects that may or may not support direct keyed access.

As a result, the `At` lens now uses `childAt`, so that microstates can also be traversed, not just POJOs. However, only for the `view` operation. A corresponding polymorphic `setChildAt()` would be required to make a change.