### PR TITLE
Make transitions in a store return latest node at transition path.

### DIFF
--- a/src/identity.js
+++ b/src/identity.js
@@ -76,7 +76,12 @@ export default function Identity(microstate, observe = x => x) {
         }, current);
         let next = microstate[name](...args);
 
-        return next === current ? identity : tick(next);
+        if (next !== current) {
+          tick(next);
+          return this;
+        } else {
+          return view(Path(path), pathmap);
+        }
       };
       return methods;
     }, {}, methods));

--- a/tests/identity.test.js
+++ b/tests/identity.test.js
@@ -13,63 +13,63 @@ describe('Identity', () => {
   describe('complex type', () => {
     let id;
     let microstate;
+    let latest;
     beforeEach(function() {
       microstate = create(TodoMVC)
         .todos.push({ title: "Take out The Milk", completed: true })
         .todos.push({ title: "Convince People Microstates is awesome" })
         .todos.push({ title: "Take out the Trash" })
         .todos.push({ title: "profit $$"});
-      id = Identity(microstate);
+      latest = id = Identity(microstate, x => latest = x);
     });
-  
+
     it('is derived from its source object', function() {
       expect(id).toBeInstanceOf(TodoMVC);
     });
-  
+
     it('has the same shape as the initial state.', function() {
       expect(id.completeAll).toBeInstanceOf(Function);
       expect(id.todos).toHaveLength(4);
-  
+
       let [ first ] = id.todos;
       let [ $first ] = microstate.todos;
       expect(first).toBeInstanceOf(Todo);
       expect(valueOf(first)).toBe(valueOf($first));
     });
-  
+
     describe('invoking a transition', function() {
-      let next, third;
+      let third;
       beforeEach(function() {
         [ ,, third ] = id.todos;
-  
-        next = third.completed.set(true);
+
+        third.completed.set(true);
       });
-  
+
       it('transitions the nodes which did change', function() {
-        expect(next).not.toBe(id);
-        expect(next.todos).not.toBe(id.todos);
-        let [ ,, $third] = next.todos;
+        expect(latest).not.toBe(id);
+        expect(latest.todos).not.toBe(id.todos);
+        let [ ,, $third] = latest.todos;
         expect($third).not.toBe(third);
       });
-  
+
       it('maintains the === identity of the nodes which did not change', function() {
         let [first, second, third, fourth] = id.todos;
-        let [$first, $second, $third, $fourth] = next.todos;
+        let [$first, $second, $third, $fourth] = latest.todos;
         expect($third.title).toBe(third.title);
         expect($first).toBe(first);
         expect($second).toBe(second);
         expect($fourth).toBe(fourth);
       });
     });
-  
+
     describe('implicit method binding', function() {
-      let next;
       beforeEach(function() {
         let shift = id.todos.shift;
-        next = shift();
+        shift();
       });
-  
+
       it('still completes the transition', function() {
-        expect(valueOf(next)).toEqual({
+        expect(valueOf(latest)).toEqual({
           todos: [{
             title: "Convince People Microstates is awesome"
           }, {
@@ -80,38 +80,37 @@ describe('Identity', () => {
         });
       });
     });
-  
+
     describe('transition stability', function() {
-      let next;
       beforeEach(function() {
         let [ first ] = id.todos;
-        next = first.completed.set(false);
+        first.completed.set(false);
       });
-  
+
       it('uses the same function for each location in the graph, even for different instances', function() {
-        expect(next).not.toBe(id);
-        expect(next.set).toBe(id.set);
-  
+        expect(latest).not.toBe(id);
+        expect(latest.set).toBe(id.set);
+
         let [ first ] = id.todos;
-        let [ $first ] = next.todos;
-  
+        let [ $first ] = latest.todos;
+
         expect($first.push).toBe(first.push);
         expect($first.completed.toggle).toBe(first.completed.toggle);
       });
     });
-  
+
     describe('the identity callback function', function() {
       let store;
       beforeEach(function() {
         store = Identity(microstate, () => undefined);
       });
-  
+
       it('ignores the return value of the callback function when determining the value of the store', function() {
         expect(store).toBeDefined();
         expect(store).toBeInstanceOf(TodoMVC);
       });
     });
-  
+
     describe('idempotency', function() {
       let calls;
       let store;
@@ -124,47 +123,46 @@ describe('Identity', () => {
         let [ first ] = store.todos;
         first.completed.set(true);
       });
-  
+
       it('does not invoke the idenity function on initial invocation', function() {
         expect(calls).toEqual(0);
       });
     });
-  
+
     describe('identity of queries', function() {
       it('traverses queries and includes the microstates within them', function() {
         expect(id.completed).toBeDefined();
         let [ firstCompleted ] = id.completed;
         expect(firstCompleted).toBeInstanceOf(Todo);
       });
-  
+
       describe('the effect of transitions on query identities', () => {
-        let next;
         beforeEach(function() {
           let [ first ] = id.completed;
-          next = first.title.set('Take out the milk');
+          first.title.set('Take out the milk');
         });
-  
+
         it('updates those queries which contain changed objects, but not ids *within* the query that remained the same', () => {
           let [first, second] = id.completed;
-          let [$first, $second] = next.completed;
-          expect(next.completed).not.toBe(id.completed);
+          let [$first, $second] = latest.completed;
+          expect(latest.completed).not.toBe(id.completed);
           expect($first).not.toBe(first);
           expect($second).toBe(second);
         });
-  
+
         it.skip('maintains the === identity of those queries which did not change', function() {
           let [first, second] = id.active;
-          let [$first, $second] = next.active;
+          let [$first, $second] = latest.active;
           expect($first).toBe(first);
           expect($second).toBe(second);
-          expect(next.active).toBe(id.active);
+          expect(latest.active).toBe(id.active);
         });
-  
+
         it('maintains the === identity of the same node that appears at different spots in the tree', () => {
           let [ first ] = id.todos;
           let [ firstCompleted ] = id.completed;
-          let [ $first ] = next.todos;
-          let [ $firstCompleted ] = next.completed;
+          let [ $first ] = latest.todos;
+          let [ $firstCompleted ] = latest.completed;
           expect(first).toBe(firstCompleted);
           expect($first).toBe($firstCompleted);
         });
@@ -180,7 +178,7 @@ describe('Identity', () => {
     }
 
     it('it keeps both branches', () => {
-      let s = Identity(create(Person), next => (s = next));
+      let s = Identity(create(Person), latest => (s = latest));
       let { name, father, mother } = s;
 
       name.set('Bart');
@@ -202,7 +200,7 @@ describe('Identity', () => {
   describe('identity support for microstates created with from(object)', () => {
     let i;
     beforeEach(() => {
-      i = Identity(from({ name: 'Taras' }), next => i = next);
+      i = Identity(from({ name: 'Taras' }), latest => i = latest);
       i.name.concat('!!!');
     });
     it('allows to transition value of a property', () => {
@@ -221,7 +219,7 @@ describe('Identity', () => {
 
     let i, setA;
     beforeEach(() => {
-      i = Identity(create(Child), next => i = next);
+      i = Identity(create(Child), latest => i = latest);
       setA = i.setA;
     });
 


### PR DESCRIPTION
As it stands, a microstate created “in the wild” with the `create()` function always returns an instance of that microstate for all of its transitions and all of its child transitions.

```js
create(class Counter { count = Number; })
  .set({ count: 5 })
  .count.increment()
  .count.increment(-3)
```

This makes sense within the context of a transition, where you’re always dealing with the root node of the thing being transitioned. Microstates inside a store follow this pattern currently, but I’m not so sure it’s a good idea.  The reason is that most of the time, when you’re invoking a transition from a microstate referenced in a store, you:

1. are not invoking a chain, you’re invoking the outermost transition
2. you’re working with a “slice” of the tree, not the entire tree

So this API isn’t as useful, and it could even be bad. The reason this occured to me is in the modelling of side-effects.

For example, imagine you have a (contrived) microstate tree that looks like this:

```js
class App {
  router = class Router {
    avatars = class AvatarPage {
      uploader = Uploader {
        uploads = [Upload];
        editor = Editor;
    };
  };
}
```
and I want to have some effect-ful logic that operates just on the file uploads. For an example, see:

https://github.com/cowboyd/microstates-file-upload/blob/master/src/uploader-controller.js#L63-L77)

In microstates today, every transition returns the root of the tree. In other words, if this uploader were embedded into the `App` object like above, then the result of `upload.start()` would be an `App` object:

```js
upload.start() //=> App {}
```

Not only is this not really useful, it’s potentially dangerous in that we’re effectively “leaking” the enclosing context into a sub-context. What if we wanted to take our App, and put it into a multi-tenant platform like:

```js
class Platform {
  apps = [App];
}
```

If you had an upload that was somehow depending on the fact that `upload.start()` returned an `App` microstate, it would break when suddenly it now returns a `Platform` microstate.  and we _always_ want to be able to embed microstates into other microstates without negative consequences.

Pursuant to the discussion on slack, this implements option (1) where transitions always return the "freshest" version of the microstate at a given path.

```js

upload //=> Upload.New {}
upload.start() //=> Upload.Started {}
```