### PR TITLE
Remove useless `promap`

### DIFF
--- a/src/meta.js
+++ b/src/meta.js
@@ -41,25 +41,23 @@ export function mount(microstate, substate, key) {
   let parent = view(Meta.data, microstate);
   let prefix = compose(parent.lens, At(key, parent.value));
 
-  return promap(x => x, object => {
-    return over(Meta.data, meta => ({
-      get root() {
-        return parent.root;
-      },
-      get lens() {
-        return compose(prefix, meta.lens);
-      },
-      get path() {
-        return parent.path.concat([key]).concat(meta.path);
-      },
-      get value() {
-        return meta.value;
-      },
-      get source() {
-        return meta.source;
-      }
-    }), object);
-  }, substate);
+  return over(Meta.data, meta => ({
+    get root() {
+      return parent.root;
+    },
+    get lens() {
+      return compose(prefix, meta.lens);
+    },
+    get path() {
+      return parent.path.concat([key]).concat(meta.path);
+    },
+    get value() {
+      return meta.value;
+    },
+    get source() {
+      return meta.source;
+    }
+  }), substate);
 }
 
 export const Profunctor = type(class {


### PR DESCRIPTION
Back when the microstate tree was eagerly evaluated, we had to whenever we mounted one tree onto another we had to map over the entire tree in memory and update the metadata associated with each node in order to adjust its path and so forth.

But now that the tree is evaluated completely lazily, this type of mapping is no longer necessary. Instead it is enough to derive the mounted substate from the current state which is its parent, and all subsequent substates will do the same.

Note that this is the first step towards removing the `Profunctor` class altogether.