### PR TITLE
Base the identity store on a map of paths to stable references.

### DIFF
--- a/src/identity.js
+++ b/src/identity.js
@@ -1,92 +1,10 @@
-import { foldl } from 'funcadelic';
-import { promap, valueOf, pathOf, Meta } from './meta';
-import { methodsOf } from './reflection';
+import { valueOf } from './meta';
 
-//function composition should probably not be part of lens :)
-import { At, view, Path, compose, set } from './lens';
-
-class Location {
-  static id = At(Symbol('@id'));
-}
+import Storage from './storage';
+import Pathmap from './pathmap';
 
 export default function Identity(microstate, observe = x => x) {
-  let current;
-  let identity;
-  let pathmap = {};
-
-  function tick(next) {
-    update(next);
-    observe(identity);
-    return identity;
-  }
-
-  function update(microstate) {
-    current = microstate;
-    return identity = promap(proxify, persist, microstate);
-
-    function proxify(microstate) {
-      let path = pathOf(microstate);
-      let Type = microstate.constructor.Type;
-      let value = valueOf(microstate);
-
-      let id = view(compose(Path(path), Location.id), pathmap);
-
-      let Id = id != null && id.constructor.Type === Type ? id.constructor : IdType(Type, path);
-      return new Id(value);
-    }
-
-    function persist(id) {
-      let location = compose(Path(id.constructor.path), Location.id);
-      let existing = view(location, pathmap);
-      if (!equals(id, existing)) {
-        pathmap = set(location, id, pathmap);
-        return id;
-      } else {
-        return existing;
-      }
-    }
-  }
-
-  function IdType(Type, P) {
-    class Id extends Type {
-      static Type = Type;
-      static path = P;
-      static name = `Id<${Type.name}>`;
-
-      constructor(value) {
-        super(value);
-        Object.defineProperty(this, Meta.symbol, { enumerable: false, configurable: true, value: new Meta(this, valueOf(value))});
-      }
-    }
-
-    let methods = Object.keys(methodsOf(Type)).concat(["set"]);
-
-    Object.assign(Id.prototype, foldl((methods, name) => {
-      methods[name] = function(...args) {
-        let microstate = view(Path(Id.path), current);
-
-        let next = microstate[name](...args);
-
-        if (next !== current) {
-          tick(next);
-          return this;
-        } else {
-          return view(Path(Id.path), pathmap);
-        }
-      };
-      return methods;
-    }, {}, methods));
-
-    return Id;
-  }
-  update(microstate);
-  return identity;
-}
-
-function equals(id, other) {
-  if (other == null) {
-    return false;
-  } else {
-    return other.constructor.Type === id.constructor.Type && valueOf(id) === valueOf(other);
-  }
+  let { Type } = microstate.constructor;
+  let pathmap = Pathmap(Type, new Storage(valueOf(microstate), () => observe(pathmap.get())));
+  return pathmap.get();
 }

--- a/src/meta.js
+++ b/src/meta.js
@@ -1,15 +1,12 @@
-import { type, append } from 'funcadelic';
 import { At, compose, transparent, over, view } from './lens';
 
 export class Meta {
   static symbol = Symbol('Meta');
   static data = At(Meta.symbol);
-  static context = compose(Meta.data, At('context'));
   static lens = compose(Meta.data, At('lens'));
   static path = compose(Meta.data, At('path'));
   static value = compose(Meta.data, At('value'));
   static source = compose(Meta.data, At('source'));
-  static Type = compose(Meta.data, At('Type'));
 
   constructor(object, value) {
     this.root = object;
@@ -59,35 +56,3 @@ export function mount(microstate, substate, key) {
     }
   }), substate);
 }
-
-export const Profunctor = type(class {
-  static name = 'Profunctor';
-
-  promap(input, output, object) {
-    if (metaOf(object) == null) {
-      return object;
-    } else {
-      return this(object).promap(input, output, object);
-    }
-  }
-});
-
-export const { promap } = Profunctor.prototype;
-
-Profunctor.instance(Object, {
-  promap(input, output, object) {
-    let next = input(object);
-    let keys = Object.keys(object);
-    if (next === object || keys.length === 0) {
-      return output(next);
-    } else {
-      return output(append(next, keys.reduce((properties, key) => {
-        return append(properties, {
-          get [key]() {
-            return promap(input, output, object[key]);
-          }
-        });
-      }, {})));
-    }
-  }
-});

--- a/src/pathmap.js
+++ b/src/pathmap.js
@@ -1,0 +1,89 @@
+import { methodsOf } from './reflection';
+import { create } from './microstates';
+import { view, Path } from './lens';
+import { valueOf, Meta } from './meta';
+import { defineChildren } from './tree';
+import { stable } from 'funcadelic';
+
+import Storage from './storage';
+// TODO: explore compacting non-existent locations (from removed arrays and objects).
+
+export default function Pathmap(Root, ref) {
+  let paths = new Storage();
+
+  class Location {
+
+    static symbol = Symbol('Location');
+
+    static allocate(path) {
+      let existing = paths.getPath(path.concat(Location.symbol));
+      if (existing) {
+        return existing;
+      } else {
+        let location = new Location(path);
+        paths.setPath(path, { [Location.symbol]: location });
+        return location;
+      }
+    }
+
+    get currentValue() {
+      return view(this.lens, ref.get());
+    }
+
+    get reference() {
+      if (!this.currentReference || (this.currentValue !== valueOf(this.currentReference))) {
+        return this.currentReference = this.createReference();
+      } else {
+        return this.currentReference;
+      }
+    }
+
+    get microstate() {
+      return view(this.lens, create(Root, ref.get()));
+    }
+
+    constructor(path = []) {
+      this.path = path;
+      this.lens = Path(path);
+      this.createReferenceType = stable(Type => {
+        let location = this;
+        let typeName = Type.name ? Type.name: 'Unknown';
+
+        class Reference extends Type {
+          static name = `Ref<${typeName}>`;
+          static location = location;
+
+          constructor(value) {
+            super(value);
+            Object.defineProperty(this, Meta.symbol, { enumerable: false, configurable: true, value: new Meta(this, valueOf(value))});
+            defineChildren(key => Location.allocate(path.concat(key)).reference, this);
+          }
+        }
+
+        for (let methodName of Object.keys(methodsOf(Type)).concat("set")) {
+          Reference.prototype[methodName] = (...args) => {
+            let microstate = location.microstate;
+            let next = microstate[methodName](...args);
+            ref.set(valueOf(next));
+            return location.reference;
+          };
+        }
+
+        return Reference;
+      });
+    }
+
+    createReference() {
+      let { Type } = this.microstate.constructor;
+      let Reference = this.createReferenceType(Type);
+
+      return new Reference(this.currentValue);
+    }
+
+    get(reference = paths.getPath([Location.symbol, 'reference'])) {
+      return reference.constructor.location.reference;
+    }
+  }
+
+  return Location.allocate([]);
+}

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,0 +1,28 @@
+import { view, set, Path } from './lens';
+
+export default class Storage {
+  constructor(value, observe = x => x) {
+    this.value = value;
+    this.observe = observe;
+  }
+
+  get() {
+    return this.value;
+  }
+
+  set(value) {
+    if (value !== this.value) {
+      this.value = value;
+      this.observe();
+    }
+    return this;
+  }
+
+  getPath(path) {
+    return view(Path(path), this.value);
+  }
+
+  setPath(path, value) {
+    return this.set(set(Path(path), value, this.value));
+  }
+}

--- a/src/tree.js
+++ b/src/tree.js
@@ -1,5 +1,7 @@
 import { type } from 'funcadelic';
 
+import CachedProperty from './cached-property';
+
 export const Tree = type(class {
   childAt(key, parent) {
     if (parent[Tree.symbol]) {
@@ -8,6 +10,16 @@ export const Tree = type(class {
       return parent[key];
     }
   }
+
+  defineChildren(fn, parent) {
+    if (parent[Tree.symbol]) {
+      return this(parent).defineChildren(fn, parent);
+    } else {
+      for (let property of Object.keys(parent)) {
+        Object.defineProperty(parent, property, CachedProperty(property, () => fn(property, parent)));
+      }
+    }
+  }
 });
 
-export const { childAt } = Tree.prototype;
+export const { childAt, defineChildren } = Tree.prototype;

--- a/src/types/array.js
+++ b/src/types/array.js
@@ -1,6 +1,5 @@
-import { append } from 'funcadelic';
 import { At, set } from '../lens';
-import { Profunctor, promap, mount, valueOf } from '../meta';
+import { mount, valueOf } from '../meta';
 import { create } from '../microstates';
 import parameterized from '../parameterized';
 import { Tree, childAt } from '../tree';
@@ -124,32 +123,6 @@ export default parameterized(T => class ArrayType {
             };
           }
         });
-      }
-    });
-
-    Profunctor.instance(this, {
-      promap(input, output, array) {
-        let next = input(array);
-        let value = valueOf(array);
-        let length = value.length;
-        if (length === 0) {
-          return output(next);
-        } else {
-          return output(append(next, {
-            [Symbol.iterator]() {
-              let iterator = array[Symbol.iterator]();
-              return {
-                next() {
-                  let next = iterator.next();
-                  return {
-                    get done() { return next.done; },
-                    get value() { return promap(input, output, next.value); }
-                  };
-                }
-              };
-            }
-          }));
-        }
       }
     });
   }

--- a/src/types/array.js
+++ b/src/types/array.js
@@ -103,6 +103,27 @@ export default parameterized(T => class ArrayType {
         } else {
           return array[key];
         }
+      },
+
+      defineChildren(fn, array) {
+        let generate = array[Symbol.iterator];
+        return Object.defineProperty(array, Symbol.iterator, {
+          enumerable: false,
+          value() {
+            let iterator = generate.call(array);
+            let i = 0;
+            return {
+              next() {
+                let next = iterator.next();
+                let index = i++;
+                return {
+                  get done() { return next.done; },
+                  get value() { return fn(index, next.value, array); }
+                };
+              }
+            };
+          }
+        });
       }
     });
 

--- a/tests/identity.test.js
+++ b/tests/identity.test.js
@@ -137,13 +137,13 @@ describe('Identity', () => {
       });
 
       describe('the effect of transitions on query identities', () => {
+        let first, second;
         beforeEach(function() {
-          let [ first ] = id.completed;
+          [ first, second ] = id.completed;
           first.title.set('Take out the milk');
         });
 
         it('updates those queries which contain changed objects, but not ids *within* the query that remained the same', () => {
-          let [first, second] = id.completed;
           let [$first, $second] = latest.completed;
           expect(latest.completed).not.toBe(id.completed);
           expect($first).not.toBe(first);

--- a/tests/pathmap.test.js
+++ b/tests/pathmap.test.js
@@ -37,7 +37,7 @@ describe('pathmap', ()=> {
     expect(valueOf(id)).toBe(ref.get());
   });
 
-  it('has children corresponding to the shit to the substates', ()=> {
+  it('has children corresponding to the substates', ()=> {
     expect(id.hall).toBeInstanceOf(BooleanType);
     expect(id.closet).toBeInstanceOf(BooleanType);
   });

--- a/tests/pathmap.test.js
+++ b/tests/pathmap.test.js
@@ -1,0 +1,123 @@
+/* global describe, beforeEach, it */
+
+import expect from 'expect';
+
+import Pathmap from '../src/pathmap';
+import { valueOf, BooleanType, ArrayType, NumberType } from '../index';
+
+describe('pathmap', ()=> {
+
+  let pathmap;
+  let LightSwitch;
+  let ref;
+  let id;
+  let hall;
+  let closet;
+
+  let current;
+  beforeEach(()=> {
+    ref = Ref({});
+    LightSwitch = class LightSwitch {
+      hall = Boolean;
+      closet = Boolean;
+    };
+    pathmap = Pathmap(LightSwitch, ref);
+    id = pathmap.get();
+    hall = id.hall;
+    closet = id.closet;
+
+    current = pathmap.get;
+  });
+
+  it('exists', () => {
+    expect(pathmap).toBeDefined();
+  });
+  it('has an id delegate which is represents the microstate at the base path', ()=> {
+    expect(id).toBeInstanceOf(LightSwitch);
+    expect(valueOf(id)).toBe(ref.get());
+  });
+
+  it('has children corresponding to the shit to the substates', ()=> {
+    expect(id.hall).toBeInstanceOf(BooleanType);
+    expect(id.closet).toBeInstanceOf(BooleanType);
+  });
+
+  describe('transitioning a substate', ()=> {
+    beforeEach(()=> {
+      id.hall.set(true);
+    });
+    it('updates the reference', ()=> {
+      expect(ref.get()).toEqual({
+        hall: true
+      });
+    });
+    it('changes the object representing the reference to the toggled switch', ()=> {
+      expect(pathmap.get(id).hall).not.toBe(hall);
+    });
+    it('changes the root reference if you fetch it again from the pathmap', ()=> {
+      expect(pathmap.get()).not.toBe(id);
+    });
+    it('leaves the object representing the un-touched switch to be the same', ()=> {
+      expect(id.closet).toBe(closet);
+    });
+
+    it('can fetch the current value based off of the old one.', ()=> {
+      expect(current(hall)).toBe(current(id).hall);
+      expect(current(id)).toBe(pathmap.get());
+    });
+
+    it('keeps all the methods stable at each location.', ()=> {
+      expect(hall.set).toBe(id.hall.set);
+    });
+  });
+
+  describe('working with arrays', ()=> {
+    beforeEach(()=> {
+      pathmap = Pathmap(ArrayType.of(Number), Ref([1, 2, 3]));
+      id = pathmap.get();
+    });
+    it('creates a proxy object for all of its children', ()=> {
+      let [ one, two, three ] = id;
+      expect(one).toBeInstanceOf(NumberType);
+      expect(one.constructor.name).toBe('Ref<Number>');
+      expect(two).toBeInstanceOf(NumberType);
+      expect(two.constructor.name).toBe('Ref<Number>');
+      expect(three).toBeInstanceOf(NumberType);
+      expect(three.constructor.name).toBe('Ref<Number>');
+    });
+
+    describe('transitioning one of the contents', ()=> {
+      let first, second, third;
+      beforeEach(()=> {
+        let [one, two, three] = id;
+        first = one;
+        second = two;
+        third = three;
+        two.increment();
+      });
+      it('changes the root id', ()=> {
+        expect(current(id)).not.toBe(id);
+      });
+      it('changes the array member that changed.', ()=> {
+        expect(current(second)).not.toBe(second);
+      });
+      it('leaves the remaining children that did not change alone', ()=> {
+        expect(current(first)).toBe(first);
+        expect(current(third)).toBe(third);
+      });
+    });
+
+  });
+
+});
+
+function Ref(value) {
+  let ref = {
+    get() { return value; },
+    set(newValue) {
+      value = newValue;
+      return ref;
+    }
+  };
+  return ref;
+}


### PR DESCRIPTION
The store implementation is currently based on a tree mapping algorithm that, though lazy, is theoretically a mapping of the entire microstate tree. This worked well when what we were doing with the store was walking the entire tree as part of a render() cycle that starts at the top and then enumerates all children.

The problem with this is that it does not allow you to enter the graph at any point. This is pretty necessary when modelling side-effects, where you might want to be able to find out what the current stable reference is for a node that you might be working with over a long time.

Originally modelled using This replaces the tree mapping strategy with a "pathmap" strategy. When a microstate is enumerated or accessed, a `Location` object is allocated for it at that path. So, for example the progress of the second upload of the uploader would have a path `['uploads', 1, 'progress']`. Once allocated, that location _never changes_, which allows us to look up a location directly if we have its path.

The `Location` has all the information needed to work with that path: the current POJO value at that path, the microstate in the tree at that path, and the `reference` which is of the same type as the microstate that will be stable and proxy that microstate.

While the `Location` never changes, the `reference` that it holds does change as the underlying value changes. This is what provides us with a stable, yet immutable structure.

So, in our uploader example:

```js
class Uploader {
  uploads = [class Upload {}]
}
```

The location / reference structure would look like:

```
┌───────────┐                    ┌───────────┐
│           │                    │           │
│ Location  │───reference───────▶│ Uploader  │
│           │                    │           │
└──────┬────┘                    └─────┬─────┘
       │                               │
       │                               │
       │                               │          ┌───────────┐
       │         ┌───────────┐         │ uploads  │           │
       │uploads  │           │         └─────────▶│ [Upload]  │
       └────────▶│ Location  │──reference────────▶│           │
                 │           │                    └───────────┘
                 └────┬──────┘                         │
                      │                                            ┌────────┐
                      │           ┌───────────┐        │           │        │
                      │ 0         │           │        │─ ─ ─ ─ ─ ▶│ Upload │
                      ├──────────▶│ Location  │───reference───────▶│        │
                      │           │           │        │           └────────┘
                      │           └───────────┘
                      │                                │
                      │                                            ┌────────┐
                      │           ┌───────────┐        │           │        │
                      │ 1         │           │         ─ ─ ─ ─ ─ ▶│ Upload │
                      └──────────▶│ Location  │───reference───────▶│        │
                                  │           │                    └────────┘
                                  └───────────┘
```
Notice how the array of Uploads `[Upload]` does not actually have keyed access to its children. Those are lazily enumerated. However, once they _are_ enumerated, then we can assign them a location based on the position they appeared in when they were enumerated. This allows us to leap right back to that position if we need to work with this element in the future (as in the case where we want to report progress on a specific upload as it happens).

Notes:

 - I'm not thrilled about the `defineChildren` mechanism, but there has to be a way for these references to "intercept" children and replace them with further references. Specifically, this behavior must be different between Arrays and other container classes. I think this can be generalized in the future, but I think that there has to be some clarification on where the DSL officially hooks into the relationship definition process. I think

 - The `Profunctor` typeclass is now completely obsolete and should be removed in a follow-on change.

 - The storage class is just a very light-weight method for keeping a POJO, working with various paths within it, and receiving notifications of when it changes.