### PR TITLE
Give new `Tree` typeclass an explicit name.

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -3,6 +3,8 @@ import { type } from 'funcadelic';
 import CachedProperty from './cached-property';
 
 export const Tree = type(class {
+  static name = 'Tree';
+
   childAt(key, parent) {
     if (parent[Tree.symbol]) {
       return this(parent).childAt(key, parent);


### PR DESCRIPTION
Uglify erases class names, which can break builds that use it. We ran into this issue before with the `Profunctor` typeclass. 

This adds an  explicit name for the `Tree` typeclass so that we don't run into the same issue.