### PR TITLE
Don't try to reify a value if the iteration is finished.

### DIFF
--- a/src/types/array.js
+++ b/src/types/array.js
@@ -86,7 +86,13 @@ export default parameterized(T => class ArrayType {
         let index = i++;
         return {
           get done() { return next.done; },
-          get value() { return !next.done ? childAt(index, array) : undefined; }
+          get value() {
+            if (!next.done) {
+              return childAt(index, array);
+            } else {
+              return undefined;
+            }
+          }
         };
       }
     };
@@ -118,7 +124,11 @@ export default parameterized(T => class ArrayType {
                 return {
                   get done() { return next.done; },
                   get value() {
-                    return !next.done ? fn(index, next.value, array) : undefined;
+                    if (!next.done) {
+                      return fn(index, next.value, array);
+                    } else {
+                      return undefined;
+                    }
                   }
                 };
               }

--- a/src/types/array.js
+++ b/src/types/array.js
@@ -86,7 +86,7 @@ export default parameterized(T => class ArrayType {
         let index = i++;
         return {
           get done() { return next.done; },
-          get value() { return childAt(index, array); }
+          get value() { return !next.done ? childAt(index, array) : undefined; }
         };
       }
     };
@@ -117,7 +117,9 @@ export default parameterized(T => class ArrayType {
                 let index = i++;
                 return {
                   get done() { return next.done; },
-                  get value() { return fn(index, next.value, array); }
+                  get value() {
+                    return !next.done ? fn(index, next.value, array) : undefined;
+                  }
                 };
               }
             };

--- a/src/types/object.js
+++ b/src/types/object.js
@@ -54,7 +54,13 @@ export default parameterized(T => class ObjectType {
         let next = iterator.next();
         return {
           get done() { return next.done; },
-          get value() { return !next.done ? new Entry(next.value, object[next.value]) : undefined; }
+          get value() {
+            if (!next.done) {
+              return new Entry(next.value, object[next.value]);
+            } else {
+              return undefined;
+            }
+          }
         };
       }
     };

--- a/src/types/object.js
+++ b/src/types/object.js
@@ -54,7 +54,7 @@ export default parameterized(T => class ObjectType {
         let next = iterator.next();
         return {
           get done() { return next.done; },
-          get value() { return new Entry(next.value, object[next.value]); }
+          get value() { return !next.done ? new Entry(next.value, object[next.value]) : undefined; }
         };
       }
     };

--- a/tests/types/array.test.js
+++ b/tests/types/array.test.js
@@ -4,6 +4,7 @@ import expect from 'expect';
 import ArrayType from '../../src/types/array';
 import { create } from '../../src/microstates';
 import { valueOf } from '../../src/meta';
+import { Store } from '../../index';
 
 describe("ArrayType", function() {
 
@@ -477,4 +478,15 @@ describe("ArrayType", function() {
       expect(array.remove(null)).toBe(array);
     });
   });
+
+  describe('within a Store', ()=> {
+    it('return undefined at the end of an iteration', ()=> {
+      let array = Store(create([Number], [1,2]));
+      let iterator = array[Symbol.iterator]();
+      iterator.next();
+      iterator.next();
+      expect(iterator.next().value).toBe(undefined);
+    });
+  });
+
 });

--- a/tests/types/array.test.js
+++ b/tests/types/array.test.js
@@ -435,6 +435,16 @@ describe("ArrayType", function() {
       expect(substates).toHaveLength(3);
     });
 
+    it('has undefined as the value of a done iteration', function() {
+      let iterator = array[Symbol.iterator]();
+      iterator.next();
+      iterator.next();
+      iterator.next();
+      let last = iterator.next();
+      expect(last.done).toBe(true);
+      expect(last.value).toBe(undefined);
+    });
+
     describe('transitinging one of the substates', function() {
       let transitioned;
       beforeEach(() => {

--- a/tests/types/object.test.js
+++ b/tests/types/object.test.js
@@ -265,5 +265,15 @@ describe("map/filter/reduce", () => {
       expect(valueOf(calls[1])).toMatchObject({key: 'b', value: 'B'});
       expect(valueOf(calls[2])).toMatchObject({key: 'c', value: 'C'});
     });
+
+    it('is undefined at the end of iteration', function() {
+      let iterator = obj[Symbol.iterator]();
+      iterator.next();
+      iterator.next();
+      iterator.next();
+      let last = iterator.next();
+      expect(last.done).toBe(true);
+      expect(last.value).toBe(undefined);
+    });
   });
 });


### PR DESCRIPTION
For each `step` of an iteration, the iterator has two properties: `step.done` and `step.value`. In the case of arrays and objects, if the `step.done` method returns false, the expectation is that you've moved past the end of list collection and that you won't even bother with calling the `step.value` because why? And this is mostly true of libraries that use iterator.

However, in the case of generator functions, each `step` represents the invocation of `yield`, and the _last_ step, in which `step.done` is `true` represents the return value of the generator function. In other words, `step.value` _can_ have a meaningful value. So for libraries that generalize over all iterators, not just collection iterators (like regenerator-runtime), we need to have `value` return something meaningful, not just a garbage entry with an invalid value.

Luckily, this is straightforward. For both `ObjectType`, and `ArrayType` we guard the iteration step value by checking first to see if the iteration is done, and return `undefined` if we've moved past the end of the collection.