### PR TITLE
Add videos section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ feel like working with the classic, mutable models we all know and love.
 </details>
 
 <details>
-  <summary><strong>🎬Videos</strong></summary>
+  <summary><strong>🎬 Videos</strong></summary>
 
   - [Building a shopping cart with Microstates.js](https://www.youtube.com/watch?v=N9iu8h0CzNY) - The Frontside YouTube - Taras Mankovski & Alex Regan
   - [State of Enjoyment](https://www.youtube.com/watch?v=zWEg4-bGot0) at Framework Summit 2018 - Charles Lowell

--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ feel like working with the classic, mutable models we all know and love.
 <!-- tocstop -->
 </details>
 
+<details>
+  <summary>Videos</summary>
+
+  - [Building a shopping cart with Microstates.js](https://www.youtube.com/watch?v=g0-nf7m1Muo&t=1s) - The Frontside YouTube - Taras Mankovski & Alex Regan
+  - [State of Enjoyment](https://www.youtube.com/watch?v=zWEg4-bGot0) at Framework Summit 2018 - Charles Lowell
+  - [Microstates: The Ember component of state management](https://www.youtube.com/watch?v=kt5aRmhaE2M&t=7s) at EmberATX 
+  - [Composable State Primitives for JavaScript with Charles Lowell & Taras Mankovski](https://www.youtube.com/watch?v=4dmcZrUdKx4) - Devchat.tv
+  -  [Composable State Management with Microstates.js](https://www.youtube.com/watch?v=g0-nf7m1Muo&t=1s) at Toronto.js - Taras Mankovski
+</details>
+
 # Features
 
 With Microstates added to your project, you get:

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ feel like working with the classic, mutable models we all know and love.
 </details>
 
 <details>
-  <summary>Videos</summary>
+  <summary><strong>🎬Videos</strong></summary>
 
-  - [Building a shopping cart with Microstates.js](https://www.youtube.com/watch?v=g0-nf7m1Muo&t=1s) - The Frontside YouTube - Taras Mankovski & Alex Regan
+  - [Building a shopping cart with Microstates.js](https://www.youtube.com/watch?v=N9iu8h0CzNY) - The Frontside YouTube - Taras Mankovski & Alex Regan
   - [State of Enjoyment](https://www.youtube.com/watch?v=zWEg4-bGot0) at Framework Summit 2018 - Charles Lowell
   - [Microstates: The Ember component of state management](https://www.youtube.com/watch?v=kt5aRmhaE2M&t=7s) at EmberATX 
   - [Composable State Primitives for JavaScript with Charles Lowell & Taras Mankovski](https://www.youtube.com/watch?v=4dmcZrUdKx4) - Devchat.tv


### PR DESCRIPTION
We want it to be easier for people to find resources around Microstates.

## Purpose

Add a section with Videos to the README.

## Method

Using `detail/summary` to break add `Videos` section under the table of contents.

## Screenshots

### Before

<img width="1107" alt="screen shot 2019-03-03 at 4 44 44 pm" src="https://user-images.githubusercontent.com/74687/53702318-ad83ca80-3dd3-11e9-9f1d-fff079dec026.png">

### After

<img width="1125" alt="screen shot 2019-03-03 at 4 44 12 pm" src="https://user-images.githubusercontent.com/74687/53702313-9cd35480-3dd3-11e9-8460-79870d64b380.png">
