### PR TITLE
Add a link to discord and invite people to chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ feel like working with the classic, mutable models we all know and love.
 <details>
   <summary>💬 <strong>Chat</strong></summary>
 
-  [Join our community on Discord](http://bit.ly/microstates-discord). Everyone is welcome. We even have a beginner channel.
+  [Join our community on Discord](http://bit.ly/microstates-discord). Everyone is welcome. If you're a new to programming join our #beginner channel where extra care is taken to support those who're just getting started. 
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/microstates/microstates.js.svg?branch=master)](https://travis-ci.org/microstates/microstates.js)
 [![Coverage Status](https://coveralls.io/repos/github/microstates/microstates.js/badge.svg?branch=master)](https://coveralls.io/github/microstates/microstates.js?branch=master)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Gitter](https://badges.gitter.im/microstates/microstates.js.svg)](https://gitter.im/microstates/microstates.js?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Chat on Discord](https://img.shields.io/discord/556202291586269214.svg)](http://bit.ly/microstates-discord)
 [![Created by The Frontside](https://img.shields.io/badge/created%20by-frontside.io-blue.svg)](https://frontside.io) [![Greenkeeper badge](https://badges.greenkeeper.io/microstates/microstates.js.svg)](https://greenkeeper.io/)
 
 [**Microstates.js is built and maintained by Frontside. Contact us for expert JavaScript consulting and training.**](https://frontside.io/services/)
@@ -64,13 +64,20 @@ feel like working with the classic, mutable models we all know and love.
 </details>
 
 <details>
-  <summary><strong>🎬 Videos</strong></summary>
+  <summary>🎬 <strong>Videos</strong></summary>
 
   - [Building a shopping cart with Microstates.js](https://www.youtube.com/watch?v=N9iu8h0CzNY) - The Frontside YouTube - Taras Mankovski & Alex Regan
   - [State of Enjoyment](https://www.youtube.com/watch?v=zWEg4-bGot0) at Framework Summit 2018 - Charles Lowell
   - [Microstates: The Ember component of state management](https://www.youtube.com/watch?v=kt5aRmhaE2M&t=7s) at EmberATX 
   - [Composable State Primitives for JavaScript with Charles Lowell & Taras Mankovski](https://www.youtube.com/watch?v=4dmcZrUdKx4) - Devchat.tv
   -  [Composable State Management with Microstates.js](https://www.youtube.com/watch?v=g0-nf7m1Muo&t=1s) at Toronto.js - Taras Mankovski
+</details>
+
+<details>
+  <summary>💬 <strong>Chat</strong></summary>
+
+  [Join our community on Discord](http://bit.ly/microstates-discord). Everyone is welcome. We even have a beginner channel.
+
 </details>
 
 # Features


### PR DESCRIPTION
This PR replaces the Gitter channel with our Discord Server. I created a bit.ly link for Discord invite and added a little call to action for beginners.

<img width="1080" alt="image" src="https://user-images.githubusercontent.com/74687/54548838-290e7b80-497f-11e9-9258-9f1927b777c6.png">
