### PR TITLE
Always derive store location value from its microstate value.

### DIFF
--- a/src/pathmap.js
+++ b/src/pathmap.js
@@ -27,7 +27,7 @@ export default function Pathmap(Root, ref) {
     }
 
     get currentValue() {
-      return view(this.lens, ref.get());
+      return valueOf(this.microstate);
     }
 
     get reference() {

--- a/tests/pathmap.test.js
+++ b/tests/pathmap.test.js
@@ -3,7 +3,7 @@
 import expect from 'expect';
 
 import Pathmap from '../src/pathmap';
-import { valueOf, BooleanType, ArrayType, NumberType } from '../index';
+import { create, valueOf, BooleanType, ArrayType, NumberType } from '../index';
 
 describe('pathmap', ()=> {
 
@@ -107,6 +107,15 @@ describe('pathmap', ()=> {
       });
     });
 
+  });
+  describe('default values of references in the pathmap', function() {
+    beforeEach(function() {
+      pathmap = Pathmap(class { number = create(Number, 42) }, Ref(undefined));
+      id = pathmap.get();
+    });
+    it('maintains the default value of the number', function() {
+      expect(id.number.state).toBe(42);
+    });
   });
 
 });


### PR DESCRIPTION
When a `Location` was created in the pathmap, it was using the value at the path in the raw POJO as the value of the Reference. However, because of microstates allowing default values, the actual value of a microstate _can_ be different than the value passed into the constructor.

In the case where you have _undefined_  as the value of the store, the raw value in the pojo is also undefined, but the value at the microstate at that path is the default.

Therefore, we need to actually use the value of the _microstate_ at that path as the value of the location, so that references will use _that_ value instead.

With this change, the `currentValue` of the `Location` looks up the path in the microstate instead of the POJO and returns that value instead.

Fixes #329