### PR TITLE
Don't store keys on the object type.

### DIFF
--- a/tests/identity.test.js
+++ b/tests/identity.test.js
@@ -201,10 +201,10 @@ describe('Identity', () => {
     let i;
     beforeEach(() => {
       i = Identity(from({ name: 'Taras' }), latest => i = latest);
-      i.name.concat('!!!');
+      i.entries.name.concat('!!!');
     });
     it('allows to transition value of a property', () => {
-      expect(i.name.state).toBe('Taras!!!');
+      expect(i.entries.name.state).toBe('Taras!!!');
     });
   });
 

--- a/tests/literal.test.js
+++ b/tests/literal.test.js
@@ -30,13 +30,13 @@ describe('Literal Syntax', function() {
 
   it('understands deeply nested objects and arrays', function() {
     let blob = literal({array: [5, { bool: true }], string: "hi", object: {object: {}}});
-    let [ first] = blob.array;
-    let [ _, second ] = first.increment().array; // eslint-disable-line no-unused-vars
+    let [ first] = blob.entries.array;
+    let [ _, second ] = first.increment().entries.array; // eslint-disable-line no-unused-vars
 
-    let ms = second.bool.toggle()
-      .string.concat(" mom")
-      .object.put('another', 'property')
-      .object.object.put('deep', 'state');
+    let ms = second.entries.bool.toggle()
+      .entries.string.concat(" mom")
+      .entries.object.put('another', 'property')
+      .entries.object.entries.object.put('deep', 'state');
 
     expect(valueOf(ms)).toEqual({
       array: [6, { bool: false }],

--- a/tests/parameterized.test.js
+++ b/tests/parameterized.test.js
@@ -75,8 +75,8 @@ describe("Parameterized Microstates: ", () => {
       let transitioned;
       beforeEach(function() {
         m = create(Counters, value);
-        let [ firstApple] = m.apples;
-        let [ _, secondOrange ] = firstApple.increment().oranges; // eslint-disable-line no-unused-vars
+        let [ firstApple] = m.entries.apples;
+        let [ _, secondOrange ] = firstApple.increment().entries.oranges; // eslint-disable-line no-unused-vars
         transitioned = secondOrange.increment();
       });
 
@@ -89,7 +89,7 @@ describe("Parameterized Microstates: ", () => {
           oranges: [50, 21],
           apples: [2, 2, 45]
         };
-        let [ first ] = transitioned.apples; // eslint-disable-line no-unused-vars
+        let [ first ] = transitioned.entries.apples; // eslint-disable-line no-unused-vars
         expect(valueOf(transitioned)).toEqual(value);
       });
     });
@@ -111,8 +111,8 @@ describe("Parameterized Microstates: ", () => {
       });
 
       it("still respects transitions", function() {
-        let [ firstApple] = m.inventory.apples;
-        let [ _, secondOrange ] = firstApple.increment().inventory.oranges; // eslint-disable-line no-unused-vars
+        let [ firstApple] = m.inventory.entries.apples;
+        let [ _, secondOrange ] = firstApple.increment().inventory.entries.oranges; // eslint-disable-line no-unused-vars
         let next = secondOrange.increment();
         expect(valueOf(next)).toEqual({
           inventory: {
@@ -166,8 +166,8 @@ describe("Parameterized Microstates: ", () => {
     });
 
     it("still respects transitions", function() {
-      let [ firstApple] = m.apples;
-      let [ _, secondOrange ] = firstApple.increment().oranges; // eslint-disable-line no-unused-vars
+      let [ firstApple] = m.entries.apples;
+      let [ _, secondOrange ] = firstApple.increment().entries.oranges; // eslint-disable-line no-unused-vars
       let next = secondOrange.increment();
       expect(valueOf(next)).toEqual({
         oranges: [50, 21],

--- a/tests/type-shifting.test.js
+++ b/tests/type-shifting.test.js
@@ -122,7 +122,7 @@ describe("type-shifting", () => {
       it("can initialize into a parameterized object", () => {
         let object = Container.create({ a: "A", b: "B", c: "C" });
         expect(valueOf(object)).toMatchObject({ a: "A", b: "B", c: "C" });
-        expect(object.a.concat).toBeInstanceOf(Function);
+        expect(object.entries.a.concat).toBeInstanceOf(Function);
       });
     });
   });
@@ -379,7 +379,7 @@ describe("type-shifting from create to parameterized object", () => {
   });
 
   it("has name with initial values", () => {
-    expect(person.parents.father).toBeInstanceOf(Parent);
+    expect(person.parents.entries.father).toBeInstanceOf(Parent);
     expect(valueOf(person)).toMatchObject({
       parents: {
         father: {

--- a/tests/types/object.test.js
+++ b/tests/types/object.test.js
@@ -27,8 +27,8 @@ describe('created without value', () => {
     });
 
     it('wraps the assigned values the parameterized type', function() {
-      expect(assigned.foo).toBeInstanceOf(Thing);
-      expect(valueOf(assigned.foo)).toEqual('bar');
+      expect(assigned.entries.foo).toBeInstanceOf(Thing);
+      expect(valueOf(assigned.entries.foo)).toEqual('bar');
     });
 
     describe('assign twice', () => {
@@ -90,7 +90,7 @@ describe('created with value', () => {
       });
 
       it('assigned is not a microstate', () => {
-        expect(assigned.name.state).toBe('Taras');
+        expect(assigned.entries.name.state).toBe('Taras');
       });
 
       it('microstate value to be part of valueOf', () => {
@@ -151,7 +151,7 @@ describe('put and delete', () => {
       });
 
       it('has name string', () => {
-        expect(object.name.state).toBe('Taras');
+        expect(object.entries.name.state).toBe('Taras');
       });
 
       it('has valueOf', () => {
@@ -208,9 +208,9 @@ describe("map/filter/reduce", () => {
     });
 
     it("completes each todo", () => {
-      expect(mapped["a"].completed.state).toEqual(true);
-      expect(mapped["b"].completed.state).toEqual(true);
-      expect(mapped["c"].completed.state).toEqual(true);
+      expect(mapped.entries["a"].completed.state).toEqual(true);
+      expect(mapped.entries["b"].completed.state).toEqual(true);
+      expect(mapped.entries["c"].completed.state).toEqual(true);
     });
   });
 
@@ -221,9 +221,9 @@ describe("map/filter/reduce", () => {
     });
 
     it("removes completed todos", () => {
-      expect(filtered["a"]).toBeDefined();
-      expect(filtered["b"]).not.toBeDefined();
-      expect(filtered["c"]).toBeDefined();
+      expect(filtered.entries["a"]).toBeDefined();
+      expect(filtered.entries["b"]).not.toBeDefined();
+      expect(filtered.entries["c"]).toBeDefined();
     });
   });
 


### PR DESCRIPTION
Objects are a bit weird in that they actually keep all of the keys as properties of the object microstate. This has a couple of problems:

Performance
====

Because we need to iterate over all of the keys of the object value and define a property for them, it means a significant performance hit. Even though the values themselves are built lazily, the property definitions need to be created on every single construction.

Naming conflicts
====

Let's say you have an object that has keys with same names as transitions, like `{ put: 'the plate on the table' }`. This means that the _property_ "put" will override the _transition_ "put".

This seems untenable long term since it applies to every transition, including `initialize`, `delete`, `filter`..... all of them. The microstate would most likely break completely if the value had a property called "initialize".

This removes the direct properties from the Object microstate. They are still available as the `entries` property, but now they are completely contained within their own namespace and can't interfere with the Object namespace.

In practice, I expect that the `entries` property will be fairly rarely used, and in actual application, the way developers will access the substates in an object will be through enumeration.