### PR TITLE
Iterator objects should not be wrapped in arrays

### DIFF
--- a/src/types/array.js
+++ b/src/types/array.js
@@ -18,7 +18,7 @@ export default parameterized(T => class ArrayType {
   initialize(value) {
     if (value == null) {
       return [];
-    } else if (Array.isArray(value)) {
+    } else if (Array.isArray(value) || value[Symbol.iterator]) {
       return value;
     } else {
       return [value];

--- a/tests/types/array.test.js
+++ b/tests/types/array.test.js
@@ -19,6 +19,27 @@ describe("ArrayType", function() {
     });
   });
 
+  describe("created with an iterator value", () => {
+    let ms;
+    beforeEach(()=> {
+      let iterator = {
+        0: 1,
+        [Symbol.iterator]() {
+          return [1][Symbol.iterator]();
+        }
+      };
+      ms = create(ArrayType.of(Number), iterator);
+    });
+
+    it('does not wrap iterator in an array', ()=> {
+      expect([...valueOf(ms)]).toEqual([1]);
+    });
+
+    it('result of pushing an item into the array', () => {
+      expect([...valueOf(ms.push(10))]).toEqual([1, 10]);
+    });
+  });
+
   describe("when unparameterized", function() {
     let ms;
     let array = ["a", "b", "c"];


### PR DESCRIPTION
Array Microstates are iterators. It would be helpful to allow value to be iterators as well. 

Currently, when an array microstate is created with an iterator value, Microstates wraps that value in an array. This messes up the value and prevents the iterator from being used. This PR changes the initializer to detect if the value defines a `Symbol.iterator` property and interprets these as an array. 