### PR TITLE
Added find to query

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 export { create } from './src/microstates';
 export { default as from } from './src/literal';
-export { map, filter, reduce } from './src/query';
+export { map, filter, reduce, find } from './src/query';
 export { default as Store } from './src/identity';
 export { metaOf, valueOf } from './src/meta';
 export * from './src/types';

--- a/src/query.js
+++ b/src/query.js
@@ -14,6 +14,10 @@ export function reduce(iterable, fn, initial) {
   return query(iterable).reduce(fn, initial);
 }
 
+export function find(iterable, fn){
+  return query(iterable).find(fn)
+}
+
 class Query {
   constructor(iterable) {
     if (typeof iterable[Symbol.iterator] === 'function') {
@@ -73,6 +77,17 @@ class Query {
     let result = initial;
     for (let next = iterator.next(); !next.done; next = iterator.next()) {
       result = fn(result, next.value);
+    }
+    return result;
+  }
+
+  find(fn) {
+    let iterator = this.generator();
+    let result;
+    for (let next = iterator.next(); !next.done; next = iterator.next()) {
+      if (fn(next.value)) {
+        return result = next.value
+      }
     }
     return result;
   }

--- a/src/query.js
+++ b/src/query.js
@@ -82,10 +82,9 @@ class Query {
   }
 
   find(fn) {
-    let iterator = this.generator();
-    for (let next = iterator.next(); !next.done; next = iterator.next()) {
-      if (fn(next.value)) {
-        return next.value
+    for (let item of this){
+      if (fn(item)){
+        return item;
       }
     }
   }

--- a/src/query.js
+++ b/src/query.js
@@ -83,13 +83,11 @@ class Query {
 
   find(fn) {
     let iterator = this.generator();
-    let result;
     for (let next = iterator.next(); !next.done; next = iterator.next()) {
       if (fn(next.value)) {
-        return result = next.value
+        return next.value
       }
     }
-    return result;
   }
 
   [Symbol.iterator]() {

--- a/tests/query.test.js
+++ b/tests/query.test.js
@@ -7,14 +7,14 @@ import { map, filter, reduce, find } from '..';
 import { TodoMVC } from './todomvc';
 
 describe('A Microstate with queries', function() {
-  let todomvc;
-  let start = create(TodoMVC)
-    .todos.push({title: "Take out The Milk"})
-    .todos.push({title: "Convince People Microstates is awesome"})
-    .todos.push({title: "Take out the Trash"})
-    .todos.push({title: "profit $$"});
-
+  let start, todomvc;
+  
   beforeEach(function() {
+    start = create(TodoMVC)
+      .todos.push({title: "Take out The Milk"})
+      .todos.push({title: "Convince People Microstates is awesome"})
+      .todos.push({title: "Take out the Trash"})
+      .todos.push({title: "profit $$"});
     let [ first ] = start.todos;
     let [,, third ] = first.toggle().todos;
     todomvc = third.toggle();

--- a/tests/query.test.js
+++ b/tests/query.test.js
@@ -2,7 +2,7 @@
 import expect from 'expect';
 import { create } from '../src/microstates';
 import { valueOf } from '../src/meta';
-import { map, filter, reduce } from '..';
+import { map, filter, reduce, find } from '..';
 
 import { TodoMVC } from './todomvc';
 
@@ -64,5 +64,9 @@ describe('Query Array', () => {
 
   it('can filter a regular array', () => {
     expect([...filter(array, Boolean)]).toEqual([true, true]);
+  });
+
+  it('can find a regular array', ()=>{
+    expect(find(array, bool => bool == false)).toBe(false)
   });
 });

--- a/tests/query.test.js
+++ b/tests/query.test.js
@@ -8,17 +8,16 @@ import { TodoMVC } from './todomvc';
 
 describe('A Microstate with queries', function() {
   let todomvc;
-  beforeEach(function() {
-    let start = create(TodoMVC)
-      .todos.push({title: "Take out The Milk"})
-      .todos.push({title: "Convince People Microstates is awesome"})
-      .todos.push({title: "Take out the Trash"})
-      .todos.push({title: "profit $$"});
+  let start = create(TodoMVC)
+    .todos.push({title: "Take out The Milk"})
+    .todos.push({title: "Convince People Microstates is awesome"})
+    .todos.push({title: "Take out the Trash"})
+    .todos.push({title: "profit $$"});
 
+  beforeEach(function() {
     let [ first ] = start.todos;
     let [,, third ] = first.toggle().todos;
     todomvc = third.toggle();
-
   });
 
   it('can partition an array microstate using filter', function() {
@@ -48,6 +47,23 @@ describe('A Microstate with queries', function() {
       expect(next.active).toHaveLength(1);
       expect(next.completed).toHaveLength(3);
     });
+  });
+
+  describe('testing find function with microstates', function () {
+    let todos, first, third;
+    beforeEach(function(){
+      todos = start.todos;
+      [first, , third] = start.todos;
+    })
+
+    it('finds a microstate from an iterable', function () {
+       expect(valueOf(find(todos, x => x.title.state == "Take out the Trash"))).toBe(valueOf(third))
+    })
+
+    it('returns only the first result from find', function () {
+      expect(valueOf(find(todos, x => x.title.state.includes("out")))).toBe(valueOf(first))
+      expect(valueOf(find(todos, x => x.title.state.includes("out")))).not.toBe(valueOf(third))
+    })
   });
 });
 

--- a/tests/query.test.js
+++ b/tests/query.test.js
@@ -49,18 +49,18 @@ describe('A Microstate with queries', function() {
     });
   });
 
-  describe('testing find function with microstates', function () {
+  describe('finding an element within an iterable Microstate', function () {
     let todos, first, third;
     beforeEach(function(){
       todos = start.todos;
       [first, , third] = start.todos;
     })
 
-    it('finds a microstate from an iterable', function () {
+    it('can locate the desired item', function () {
        expect(valueOf(find(todos, x => x.title.state == "Take out the Trash"))).toBe(valueOf(third))
     })
 
-    it('returns only the first result from find', function () {
+    it('returns only the first result', function () {
       expect(valueOf(find(todos, x => x.title.state.includes("out")))).toBe(valueOf(first))
       expect(valueOf(find(todos, x => x.title.state.includes("out")))).not.toBe(valueOf(third))
     })
@@ -82,7 +82,7 @@ describe('Query Array', () => {
     expect([...filter(array, Boolean)]).toEqual([true, true]);
   });
 
-  it('can find a regular array', ()=>{
+  it('can find specific items inside a normal array', ()=>{
     expect(find(array, bool => bool == false)).toBe(false)
   });
 });


### PR DESCRIPTION
This PR introduces the find function inside query.

Currently, we can invoke a `filter` function on a microstate and grab the first item of the resulting array in efforts to mimic the functionality of `find`:
```js
import { create, filter } from 'microstates';

let arr = create(Array, [1, 2, 3, 4, 3])
let filtered = filter(arr, num => num == 3) // [3, 3]
let result = filtered[0] // 3
```

With `find`, returning the desired result becomes simpler:
```js
import { create, find } from 'microstates';

let arr = create(Array, [1, 2, 3, 4, 3])
let find = find(arr, num => num == 3) // 3
```

The `find` function is written in such that at the first instance of the function resulting true will stop the loop and return the result; whereas, `filter`, `reduce`, and `map` would continue its loop until the end.