### PR TITLE
Add keys, values properties to object.

### DIFF
--- a/src/types/object.js
+++ b/src/types/object.js
@@ -1,5 +1,5 @@
 import { append, filter, map } from 'funcadelic';
-import { reduce } from '../query';
+import { reduce, query } from '../query';
 import parameterized from '../parameterized';
 import { valueOf, mount } from '../meta';
 import { create } from '../microstates';
@@ -15,6 +15,14 @@ export default parameterized(T => class ObjectType {
     return reduce(this, (entries, entry) => Object.assign(entries, {
       [entry.key]: entry.value
     }), {});
+  }
+
+  get keys() {
+    return Object.keys(valueOf(this));
+  }
+
+  get values() {
+    return query(this).map(entry => entry.value);
   }
 
   initialize(value) {

--- a/tests/types/object.test.js
+++ b/tests/types/object.test.js
@@ -277,3 +277,20 @@ describe("map/filter/reduce", () => {
     });
   });
 });
+
+describe('keys and values', function() {
+  let object;
+  beforeEach(() => {
+    object = create({Number}, {one: 1, two: 2, three: 3});
+  });
+  it('has an enumeration of keys', function() {
+    let [...keys] = object.keys;
+    expect(keys).toEqual(['one', 'two', 'three']);
+  });
+  it('has an enumeration of values', function() {
+    let [ one, two, three ] = object.values;
+    expect(one.state).toEqual(1);
+    expect(two.state).toEqual(2);
+    expect(three.state).toEqual(3);
+  });
+});


### PR DESCRIPTION
Many times, you want to iterate over the values of an object, and either the keys are not important, but more likely, the key is already contained in the object.

For example, let's say you had a list over records that was stored by id

```js
let table = create({Record})
    .put('id-10', {id: 'id-10', word: 'hello'})
    .put('id-20', {id: 'id-20', word: 'goodbye'});

```
If the id is present not only on the table, but also on the record itself, then when you iterate, you don't really need to access the entry, so it's more convenient to access the value directly.

so

```js
for (let { value: row } of table) {
  // do stuff
}
```

becomes

```js
for (let row of table) {
  // do stuff
}
```

And when mapping components in JSX, it's even more clear what's going on:

```jsx
{ map(table, ({ value: row }) => <Row row={ row } /> }
```

becomes

```jsx
{  table.values.map(row => <Row row={ row } />) }
```