### PR TITLE
refactored reduce() in query.js

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -73,10 +73,9 @@ class Query {
   }
 
   reduce(fn, initial) {
-    let iterator = this.generator();
     let result = initial;
-    for (let next = iterator.next(); !next.done; next = iterator.next()) {
-      result = fn(result, next.value);
+    for (let item of this) {
+      result = fn(result, item)
     }
     return result;
   }


### PR DESCRIPTION
This PR is to remove the iterator from the reduce function in query.js while maintaining its functionality.