### PR TITLE
Abstract relationships.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Fine grained control of how related Microstates are instantiated
+  via abstract relationships
+  https://github.com/microstates/microstates.js/pull/358
+
 ## [0.14.0] - 2019-03-27
 
 ### Breaking

--- a/index.js
+++ b/index.js
@@ -3,4 +3,5 @@ export { default as from } from './src/literal';
 export { map, filter, reduce, find } from './src/query';
 export { default as Store } from './src/identity';
 export { metaOf, valueOf } from './src/meta';
+export { relationship } from './src/relationship.js';
 export * from './src/types';

--- a/src/microstates.js
+++ b/src/microstates.js
@@ -1,8 +1,9 @@
 import { append, stable, map } from 'funcadelic';
-import { set } from './lens';
+import { set, view, At } from './lens';
 import { Meta, mount, metaOf, valueOf, sourceOf } from './meta';
 import { methodsOf } from './reflection';
 import dsl from './dsl';
+import { Relationship, relationship } from './relationship';
 import Any from './types/any';
 import CachedProperty from './cached-property';
 import Observable from './observable';
@@ -29,12 +30,12 @@ const MicrostateType = stable(function MicrostateType(Type) {
     constructor(value) {
       super(value);
       Object.defineProperties(this, map((slot, key) => {
+        let relationship = slot instanceof Relationship ? slot : legacy(slot);
+
         return CachedProperty(key, self => {
-          let value = valueOf(self);
-          let expanded = expandProperty(slot);
-          let substate = value != null && value[key] != null ? expanded.set(value[key]) : expanded;
-          let mounted = mount(self, substate, key);
-          return mounted;
+          let childValue = view(At(key), valueOf(self));
+          let { Type, value } = relationship.traverse(childValue, self);
+          return mount(self, create(Type, value), key);
         });
       }, this));
 
@@ -62,14 +63,23 @@ const MicrostateType = stable(function MicrostateType(Type) {
   return Microstate;
 });
 
-function expandProperty(property) {
-  let meta = metaOf(property);
+/**
+ * Implement the legacy DSL as a relationship.
+ *
+ * Consider emitting a deprecation warning, as this will likely be
+ * removed before microstates 1.0
+ */
+
+function legacy(object) {
+  let cell;
+  let meta = metaOf(object);
   if (meta != null) {
-    return property;
+    cell = { Type: object.constructor.Type, value: valueOf(object) };
   } else {
-    let { Type, value } = dsl.expand(property);
-    return create(Type, value);
+    cell = dsl.expand(object);
   }
+  let { Type } = cell;
+  return relationship(cell.value).map(({ value }) => ({ Type, value }));
 }
 
 function hasOwnProperty(target, propertyName) {

--- a/src/microstates.js
+++ b/src/microstates.js
@@ -1,9 +1,9 @@
 import { append, stable, map } from 'funcadelic';
-import { set, view, At } from './lens';
-import { Meta, mount, metaOf, valueOf, sourceOf } from './meta';
+import { set } from './lens';
+import { Meta, mount, metaOf, sourceOf, valueOf } from './meta';
 import { methodsOf } from './reflection';
 import dsl from './dsl';
-import { Relationship, relationship } from './relationship';
+import { Relationship, Edge, relationship } from './relationship';
 import Any from './types/any';
 import CachedProperty from './cached-property';
 import Observable from './observable';
@@ -33,8 +33,7 @@ const MicrostateType = stable(function MicrostateType(Type) {
         let relationship = slot instanceof Relationship ? slot : legacy(slot);
 
         return CachedProperty(key, self => {
-          let childValue = view(At(key), valueOf(self));
-          let { Type, value } = relationship.traverse(childValue, self);
+          let { Type, value } = relationship.traverse(new Edge(self, [key]));
           return mount(self, create(Type, value), key);
         });
       }, this));

--- a/src/relationship.js
+++ b/src/relationship.js
@@ -1,4 +1,6 @@
 import { Any } from './types';
+import { view, Path } from './lens';
+import { valueOf } from './meta';
 
 export class Relationship {
 
@@ -7,10 +9,10 @@ export class Relationship {
   }
 
   flatMap(sequence) {
-    return new Relationship((value, parent) => {
-      let cell = this.traverse(value, parent);
+    return new Relationship(edge => {
+      let cell = this.traverse(edge);
       let next = sequence(cell);
-      return next.traverse(value, parent);
+      return next.traverse(edge);
     });
   }
 
@@ -25,12 +27,32 @@ export function relationship(definition) {
   if (typeof definition === 'function') {
     return new Relationship(definition);
   } else {
-    return relationship(value => {
+    return relationship(({ value }) => {
       if (value != null) {
         return { Type: Any, value };
       } else {
         return { Type: Any, value: definition };
       }
     });
+  }
+}
+
+export class Edge {
+  constructor(parent, path) {
+    this.parent = parent;
+    this.path = path;
+  }
+
+  get name() {
+    let [ name ] = this.path.slice(-1);
+    return name;
+  }
+
+  get value() {
+    return view(Path(this.path), this.parentValue);
+  }
+
+  get parentValue() {
+    return valueOf(this.parent);
   }
 }

--- a/src/relationship.js
+++ b/src/relationship.js
@@ -1,0 +1,36 @@
+import { Any } from './types';
+
+export class Relationship {
+
+  constructor(traverse) {
+    this.traverse = traverse;
+  }
+
+  flatMap(sequence) {
+    return new Relationship((value, parent) => {
+      let cell = this.traverse(value, parent);
+      let next = sequence(cell);
+      return next.traverse(value, parent);
+    });
+  }
+
+  map(fn) {
+    return this.flatMap(cell => new Relationship(() => {
+      return fn(cell);
+    }));
+  }
+}
+
+export function relationship(definition) {
+  if (typeof definition === 'function') {
+    return new Relationship(definition);
+  } else {
+    return relationship(value => {
+      if (value != null) {
+        return { Type: Any, value };
+      } else {
+        return { Type: Any, value: definition };
+      }
+    });
+  }
+}

--- a/src/relationship.js
+++ b/src/relationship.js
@@ -17,9 +17,7 @@ export class Relationship {
   }
 
   map(fn) {
-    return this.flatMap(cell => new Relationship(() => {
-      return fn(cell);
-    }));
+    return this.flatMap(cell => new Relationship(() => fn(cell)));
   }
 }
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -23,4 +23,7 @@ describe('index of module exports', () => {
     expect(index.metaOf).toBeInstanceOf(Function);
     expect(index.valueOf).toBeInstanceOf(Function);
   });
+  it('has the relationship function', () => {
+    expect(index.relationship).toBeInstanceOf(Function);
+  });
 });

--- a/tests/relationship.test.js
+++ b/tests/relationship.test.js
@@ -1,0 +1,55 @@
+/* global describe, it, beforeEach */
+
+import expect from 'expect';
+
+import { Any } from '../src/types';
+import { relationship } from '../src/relationship';
+
+describe('relationships', () => {
+  let rel;
+  describe('with absolutely nothing specified', () => {
+    beforeEach(() => {
+      rel = relationship(10);
+    });
+
+    it('reifies to using Any for the type and the passed value, }', () => {
+      expect(rel.traverse(5)).toEqual({ Type: Any, value: 5 });
+    });
+
+    it('uses the supplied value if non is given', () => {
+      expect(rel.traverse()).toEqual({ Type: Any, value: 10 });
+    });
+  });
+
+  describe('depending on the parent microstate that they are a part of', () => {
+    beforeEach(() => {
+      rel = relationship((value, parent) => {
+        if (typeof parent === 'number') {
+          return { Type: Number, value: Number(value) };
+        } else if (typeof parent === 'string') {
+          return { Type: String, value: String(value) };
+        } else {
+          return { Type: Object, value: Object(value) };
+        }
+      });
+    });
+    it('generates numbers when the parent is a number', () => {
+      expect(rel.traverse(5, 'parent')).toEqual({ Type: String, value: '5'});
+    });
+
+    it('generates strings when the parent is a string', () => {
+      expect(rel.traverse(5, 0)).toEqual({ Type: Number, value: 5});
+    });
+  });
+
+  describe('that are mapped', () => {
+    beforeEach(() => {
+      rel = relationship()
+        .map(({ value }) => ({Type: Number, value: value * 2 }));
+    });
+
+    it('executes the mapping as part of the traversal', () => {
+      expect(rel.traverse(3)).toEqual({Type: Number, value: 6});
+    });
+  });
+});

--- a/tests/relationship.test.js
+++ b/tests/relationship.test.js
@@ -3,21 +3,23 @@
 import expect from 'expect';
 
 import { Any } from '../src/types';
-import { relationship } from '../src/relationship';
+import { relationship, Edge } from '../src/relationship';
 
 describe('relationships', () => {
   let rel;
+  let e = (value) => new Edge(value, []);
+
   describe('with absolutely nothing specified', () => {
     beforeEach(() => {
       rel = relationship(10);
     });
 
     it('reifies to using Any for the type and the passed value, }', () => {
-      expect(rel.traverse(5)).toEqual({ Type: Any, value: 5 });
+      expect(rel.traverse(e(5))).toEqual({ Type: Any, value: 5 });
     });
 
     it('uses the supplied value if non is given', () => {
-      expect(rel.traverse()).toEqual({ Type: Any, value: 10 });
+      expect(rel.traverse(e())).toEqual({ Type: Any, value: 10 });
     });
   });
 
@@ -49,7 +51,23 @@ describe('relationships', () => {
     });
 
     it('executes the mapping as part of the traversal', () => {
-      expect(rel.traverse(3)).toEqual({Type: Number, value: 6});
+      expect(rel.traverse(e(3))).toEqual({Type: Number, value: 6});
+    });
+  });
+
+  describe('Edges', () => {
+    let edge;
+    beforeEach(() => {
+      edge = new Edge({one: {two: 2}}, ['one', 'two']);
+    });
+    it('knows its value', () => {
+      expect(edge.value).toEqual(2);
+    });
+    it('knows its parent value', () => {
+      expect(edge.parentValue).toEqual({one: {two: 2}});
+    });
+    it('has a name provided it is not anonymous', () => {
+      expect(edge.name).toEqual('two');
     });
   });
 });


### PR DESCRIPTION
See #357 for full details.

How to contextualize a child microstate has been a constant challenge. In other words, sometimes you want a child to take on a constant value. Sometimes you want it to take on a default value, and sometime you might want it to be completly polymorphic on what value it takes on depending on the parent.

Unfortunately, this is not possible with our current way of expressing relationships with is either with a DSL:

```js
class Counter {
  count = Number;
}
```

or with an explicitly created microstate:

```js
class Counter {
  count = create(Number, 1);
}
```

The problem is that there is no way to expand the concept of what gets created if you want to do something fancier, like copy values down the graph without resorting to intializer hacks.

This introduces a very thin concept of a _relationship_ between a parent microstate and a child microstate. The responsibility of the traversal is to take the value at the location of the target microstate and return a specifier for the child microstate.

To do this, we introduce the concept of a "Cell" which is a Type, value pair `{ Type, value }`. This is the minimal about of information required to specify a microstate. This is super light-weight because it does not require the overhead of actually `create`-ing a microstate.

It is the responsibility of a relationship to resolve a value into a cell.

> Note: in future microstates, we will use `{ Type, path }` as a cell
  specifier.

The relationship class is organized monadically so that it can be mapped, flatMapped, etc... and any relationship can be extended using `map` and `flatMap`

For example, to implement a hypothetical `child` helper which creates a specifies a substate of a given type and default value, it could look like this.

```js
function child(Type, defaultValue) {
  return relationship()
    .map(({ value }) => value != null ? {Type, value} : {Type, value: defaultValue })
}
```

This pull request does not introduce any actual changes built on the `relationship` function, but just exposes it so that we can experiment with it.