### PR TITLE
Add tests for module exports.

### DIFF
--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,0 +1,26 @@
+/* global describe, it */
+import expect from 'expect';
+
+import * as index from '../index';
+
+describe('index of module exports', () => {
+  it('has a create function', () => {
+    expect(index.create).toBeInstanceOf(Function);
+  });
+  it('has a from function for instatiating literals', () => {
+    expect(index.from).toBeInstanceOf(Function);
+  });
+  it('has map, filter, reduce, and find queries', () => {
+    expect(index.filter).toBeInstanceOf(Function);
+    expect(index.map).toBeInstanceOf(Function);
+    expect(index.reduce).toBeInstanceOf(Function);
+    expect(index.find).toBeInstanceOf(Function);
+  });
+  it('has Store constructor', () => {
+    expect(index.Store).toBeInstanceOf(Function);
+  });
+  it('has metaOf() and valueOf() for opening microstate boxes', () => {
+    expect(index.metaOf).toBeInstanceOf(Function);
+    expect(index.valueOf).toBeInstanceOf(Function);
+  });
+});

--- a/tests/query.test.js
+++ b/tests/query.test.js
@@ -2,7 +2,7 @@
 import expect from 'expect';
 import { create } from '../src/microstates';
 import { valueOf } from '../src/meta';
-import { map, filter, reduce, find } from '..';
+import { map, filter, reduce, find } from '../src/query';
 
 import { TodoMVC } from './todomvc';
 


### PR DESCRIPTION
The index is uncovered, and it's not clear what our public API is.

This adds some smoke tests to ensure that we don't accidentally remove functions if we re-arrange our exports.