### PR TITLE
Simplify Publish-Release workflow with Synchronize-with-NPM

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,48 +7,13 @@ on:
       - release-*
 
 jobs:
-  filter:
-    name: Filter for Merges and Forks
-    runs-on: ubuntu-latest
-    steps:
-    - uses: thefrontside/actions/merge-and-fork-detector@master
-      with:
-        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-
-  commit-publish:
-    name: Commit and Publish
-    runs-on: ubuntu-latest
-    needs: filter
+  publish:
+    name: Synchronize with NPM
+    runs-on: ubuntu-16.04
     steps:
     - uses: actions/checkout@v1
-
-    - name: Fetch Pull Request Labels
-      uses: thefrontside/actions/fetch-pull-request-labels@master
-      id: pr-labels
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Compute Major Minor or Patch
-      uses: thefrontside/actions/compute-major-minor-or-patch@master
-      with:
-        PR_LABELS: ${{ steps.pr-labels.outputs.PR_LABELS }}
-    
-    - name: NPM Version
-      uses: actions/npm@master
-      with:
-        args: version $MAJOR_OR_MINOR_OR_PATCH --no-git-tag-version 
-
-    - name: Commit Push and Tag Release
-      uses: thefrontside/actions/commit-push-and-tag-release@master
-      with:
-        add: package.json
+    - name: Tag and Publish
+      uses: thefrontside/actions/synchronize-with-npm@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: publish
-      uses: actions/npm@master
-      with:
-        args: publish --access=public
-      env:
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-      # Would be nice to put this in a separate workflow but github actions seems to not trigger workflows from commits that are triggered within another workflow.


### PR DESCRIPTION
# Purpose
The purpose of this PR is to take a different approach to our `publish-release` workflow. The previous setup required the workflow to push changes back to the repository which did not bode well with protected branches. We're making the workflow lighter and more robust (and functional) by requiring the user to manually update package version in the `package.json` file.

## Old Setup
After a PR was merged, the workflow fetched the labels, updated package version, pushed the updates to the repository, and then published to NPM.

## :star:New Setup:star:
User manually updates package version with the pull request. Once approved and merged, the workflow will push tags to Github and publish to NPM only after it confirms the package version has not already been published.

# TODO
- [x] Set `NPM_AUTH_TOKEN` secret in repository settings.
- [ ] Approve [PR#11](https://github.com/thefrontside/actions/pull/11) at `thefrontside/actions` for the `synchronize-with-npm`action to be live.
  - Please see the `TODO` of that pull request.
- [ ] Decide if `merge-and-fork-detector` should be kept in `publish-preview` workflow.
  - It returns helpful/instructional error codes and runs quickly which otherwise the workflow would have to build all the dependencies and run through its steps before being able to provide feedback.