### PR TITLE
Update and introduce new workflow

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -7,37 +7,18 @@ on:
       - release-*
 
 jobs:
-  filter:
-    name: Confirm NPM_AUTH_TOKEN Access
+  preview: 
+    name: Publish Preview Package
     runs-on: ubuntu-latest
-    steps:
-    - name: Confirm NPM_AUTH_TOKEN Access
-      uses: thefrontside/actions/merge-and-fork-detector@master
-      with:
-        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-
-  publish: 
-    name: Publish Commit Package
-    runs-on: ubuntu-latest
-    needs: filter
     steps:
     - uses: actions/checkout@v1
     - name: Write NPM Snapshot Version
       uses: thefrontside/actions/write-npm-snapshot-version@master
     - name: NPM Publish Commit
-      uses: actions/npm@master
-      with: 
-        args: publish --access=public --tag dev
+      uses: thefrontside/actions/npm-publish-branch-preview@master
       env:
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-
-  comment: 
-    name: Post Instruction Comment
-    runs-on: ubuntu-latest
-    needs: publish
-    steps:
-    - uses: actions/checkout@v1
-    - name: Post Comment
+    - name: Post Instructions Comment
       uses: thefrontside/actions/post-npm-usage-instructions-comment@master
-      env: 
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.POST_COMMENT_TOKEN }}

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -21,4 +21,4 @@ jobs:
     - name: Post Instructions Comment
       uses: thefrontside/actions/post-npm-usage-instructions-comment@master
       env:
-        GITHUB_TOKEN: ${{ secrets.POST_COMMENT_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_POST_COMMENT_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,48 +7,13 @@ on:
       - release-*
 
 jobs:
-  filter:
-    name: Filter for Merges and Forks
-    runs-on: ubuntu-latest
-    steps:
-    - uses: thefrontside/actions/merge-and-fork-detector@master
-      with:
-        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-
-  commit-publish:
-    name: Commit and Publish
-    runs-on: ubuntu-latest
-    needs: filter
+  publish:
+    name: Synchronize with NPM
+    runs-on: ubuntu-16.04
     steps:
     - uses: actions/checkout@v1
-
-    - name: Fetch Pull Request Labels
-      uses: thefrontside/actions/fetch-pull-request-labels@master
-      id: pr-labels
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Compute Major Minor or Patch
-      uses: thefrontside/actions/compute-major-minor-or-patch@master
-      with:
-        PR_LABELS: ${{ steps.pr-labels.outputs.PR_LABELS }}
-    
-    - name: NPM Version
-      uses: actions/npm@master
-      with:
-        args: version $MAJOR_OR_MINOR_OR_PATCH --no-git-tag-version 
-
-    - name: Commit Push and Tag Release
-      uses: thefrontside/actions/commit-push-and-tag-release@master
-      with:
-        add: package.json
+    - name: Tag and Publish
+      uses: thefrontside/actions/synchronize-with-npm@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: publish
-      uses: actions/npm@master
-      with:
-        args: publish --access=public
-      env:
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-      # Would be nice to put this in a separate workflow but github actions seems to not trigger workflows from commits that are triggered within another workflow.

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   publish:
     name: Synchronize with NPM
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - name: Tag and Publish

--- a/.github/workflows/synchronize-npm-tags.yml
+++ b/.github/workflows/synchronize-npm-tags.yml
@@ -1,0 +1,14 @@
+name: Synchronize NPM Tags
+
+on:
+  delete
+
+jobs:
+  clean:
+    name: Synchronize NPM Tags
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: thefrontside/actions/synchronize-npm-tags@master
+      env:
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
# Purpose
We created a new workflow and optimized the `publish-preview` workflow. These new updates originated from having to refactor away from `actions/npm` and we saw an opportunity to add new functionality to our automated publishing process.

# Approach
### Publish Release (On Pull Request)
  - What used to be three separate jobs (for checking NPM token, publishing, and generating comment), we combined into one. 
  - Replaced `actions/npm` with our new action [`npm-publish-branch-preview`](https://github.com/minkimcello/actions/tree/mk/npm-publish/npm-publish-branch-preview)
    - With the added functionality of npm tagging with the name of the branch so that when someone submits a PR, they can use their package right away with `npm install microstates@<branch-name>`.
  - Updated token source for comment generator so that Frontside's bot can create the comments from now on. **See TODOs below.**

### Publish Release (On Push)
  - Fixed a bug from the last [PR](https://github.com/microstates/microstates.js/pull/374) by removing -a tag to address [this issue](https://github.com/thefrontside/actions/issues/12).
  - Reverted `ubuntu-16.04` back to `ubuntu-latest`.
    - Using `ubunutu-latest` was causing issues on Github last time but we'll keep an eye on it.

### :star:New:star: Synchronize NPM Tags (On Delete)
  - This workflow is triggered on the default branch when another branch or tag is deleted on Github.
    - `synchronize-npm-tags` will cross check npm tags with branches of the repository to remove unnecessary tags. This action can take in an argument for teams that want to specify which tags to sustain.
      - The `latest` tag is never removed.
      - See [README](https://github.com/minkimcello/actions/tree/mk/npm-publish/synchronize-npm-tags) to see how argument can be passed in.
  - This workflow being triggered from the default branch has the added benefit of preventing unwelcome users from modifying this workflow's behavior.

# TODOs
- [x] Add `POST_COMMENT_TOKEN` to repository secrets from npmjs.
- [x] Approve [pull request #13](https://github.com/thefrontside/actions/pull/13) on `thefrontside/actions`.

# Learning
- The latest changes to `frontside/actions` can be viewed [here](https://github.com/thefrontside/actions/pull/13).
- New revised workflows were tested on a forked repository. You can view the results of the test runs [here](https://github.com/minkimcello/microstates.js/actions).