### PR TITLE
🐛Make sure to build before using as an NPM dependency

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -7,7 +7,7 @@ on:
       - release-*
 
 jobs:
-  preview: 
+  preview:
     name: Publish Preview Package
     runs-on: ubuntu-latest
     steps:
@@ -15,7 +15,7 @@ jobs:
     - name: Write NPM Snapshot Version
       uses: thefrontside/actions/write-npm-snapshot-version@master
     - name: NPM Publish Commit
-      uses: thefrontside/actions/npm-publish-branch-preview@master
+      uses: thefrontside/actions/npm-publish-branch-preview@cowboyd-install-before-publish
       env:
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
     - name: Post Instructions Comment

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "build": "rollup -c",
     "bench": "node -r ./tests/setup benchmarks/index.js",
-    "prepack": "npm run build"
+    "prepublishOnly": "npm run build"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "build": "rollup -c",
     "bench": "node -r ./tests/setup benchmarks/index.js",
-    "prepare": "npm run build",
-    "prerelease": "npm test && npm run build"
+    "prepack": "npm run build"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "build": "rollup -c",
     "bench": "node -r ./tests/setup benchmarks/index.js",
-    "prepublishOnly": "npm run build"
+    "prepack": "npm run build"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",


### PR DESCRIPTION
Microstates uses rollup to transpile its source and make it available in a number of different module formats. It won't work unless this step happens before a publish.

We can use the `prepack` [npm script][1] to make sure that if someone is generating a tarball, publishing, or installing as a `git` dependency that the build gets run.

[1]: https://docs.npmjs.com/misc/scripts