### PR TITLE
🐛Make sure to build before using as an NPM dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "build": "rollup -c",
     "bench": "node -r ./tests/setup benchmarks/index.js",
-    "prepare": "npm run build",
-    "prerelease": "npm test && npm run build"
+    "prepack": "npm run build"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",


### PR DESCRIPTION
Microstates uses rollup to transpile its source and make it available in a number of different module formats. It won't work unless this step happens before a publish.

We can use the `prepack` [npm script][1] to make sure that if someone
is generating a tarball, publishing, or installing as a `git` dependency that the build gets run.

- [x] First merge thefrontside/actions#16 so that the hooks will be properly run on publish

[1]: https://docs.npmjs.com/misc/scripts