### PR TITLE
Prepare release 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.15.1] - 2019-10-11
+
+### Changed
+
+- This release is identical to 0.15.0 except that there was a
+  publishing error and the resulting package released to NPM was
+  malformed. This release is generated from the same source as v0.15.0
+
 ## [0.15.0] - 2019-10-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microstates",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Composable State Primitives for JavaScript",
   "keywords": [
     "lens",


### PR DESCRIPTION
The prior release (v0.15.0) was malformed and so had to be unpublished from NPM. In all other ways this is identical.