### PR TITLE
Point README to Circle build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![npm](https://img.shields.io/npm/v/microstates.svg)](https://www.npmjs.com/package/microstates)
 [![bundle size (minified + gzip)](https://badgen.net/bundlephobia/minzip/microstates)](https://bundlephobia.com/result?p=microstates)
-[![Build Status](https://travis-ci.org/microstates/microstates.js.svg?branch=master)](https://travis-ci.org/microstates/microstates.js)
+[![Build Status](https://circleci.com/gh/microstates/microstates.js/tree/master.svg?style=shield)](https://circleci.com/gh/microstates/microstates.js/tree/master)
 [![Coverage Status](https://coveralls.io/repos/github/microstates/microstates.js/badge.svg?branch=master)](https://coveralls.io/github/microstates/microstates.js?branch=master)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Chat on Discord](https://img.shields.io/discord/556202291586269214.svg)](http://bit.ly/microstates-discord)


### PR DESCRIPTION
About 7 months ago, we switched the build from TravisCI to CircleCI but forgot to upgrade the shield in the README.

## Before
broken build shield

![image](https://user-images.githubusercontent.com/4205/66775023-b029c080-ee88-11e9-8080-9c9571690c3b.png)


## After

unbroken build shield

![image](https://user-images.githubusercontent.com/4205/66774990-9daf8700-ee88-11e9-9bc3-61d0fdd3db68.png)
