### PR TITLE
✍🏼Document the `from()` function to account for collection laziness

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,13 +768,22 @@ from({ hello: 'world' });
 //> Microstate<Object>
 ```
 
-`from` is lazy, so you can consume any deeply nested POJO and Microstates will allow you to perform transitions with it. The cost of building the objects inside of Microstates is paid whenever you reach for a Microstate inside. For example, `let o = from({ a: { b: { c: 42 }}})` doesn't do anything until you start to read the properties with dot notiation like `o.a.b.c`.
+`from` is lazy, so you can consume any deeply nested POJO and
+Microstates will allow you to perform transitions with it. The cost of
+building the objects inside of Microstates is paid whenever you reach
+for a Microstate inside. For example, `let o = from({ a: { b: { c: 42
+}}})` doesn't do anything until you start to read the properties with
+dot notiation like `o.entries` or with iteration / destructuring.
 
 ```js
-from({ a: { b: { c: 42 } } }).a.b.c.increment().state;
+let [[[[[[c]]]]]] = from({a: { b: {c: 42}}});
+valueOf(c.increment());
+
 // { a: { b: { c: 43 }}}
 
-from({ hello: ['world'] }).hello[0].concat('!!!').state;
+let greeting = from({ hello: ['world']});
+let [ world ] = greeting.entries.hello;
+valueOf(world.concat('!!!'));
 // { hello: [ 'world!!!' ]}
 ```
 


### PR DESCRIPTION
A while back, the change was made to not allow direct keyed access to [Object][1] and [Array][2]. While we updated most of the documentation to include those changes, the documentation of the `from()` method was not. As a result, this was misleading.

This change refactors the examples to use either the `entries` map on object or the destructuring which uses the iterability of both Array and Object.

resolves #385 

[1]: https://github.com/microstates/microstates.js/pull/338
[2]: https://github.com/microstates/microstates.js/pull/227